### PR TITLE
Fix __LOCATOR_DATA__ being overriden

### DIFF
--- a/packages/babel-jsx/src/index.ts
+++ b/packages/babel-jsx/src/index.ts
@@ -263,7 +263,7 @@ export default function transformLocatorJsComponents(babel: Babel): {
               window.__LOCATOR_DATA__ = window.__LOCATOR_DATA__ || {};
               window.__LOCATOR_DATA__["${createFullPath(
                 fileStorage
-              )}"] = ${dataCode};
+              )}"] ??= ${dataCode};
             }
           })()`;
 


### PR DESCRIPTION
This is probably rarely an issue, but I ran into it when my babel config was being run twice. The second time would override the locator data with missing expressions. (Which has already been transformed by then.)

My particular scenario involved a Vite plugin reusing the same babel config twice. (Specifically [solidjs/solid-start...vite/plugin.js#L739](https://github.com/solidjs/solid-start/blob/main/packages/start/vite/plugin.js#L739) and [solidjs/solid-start...vite/plugin.js#L743](https://github.com/solidjs/solid-start/blob/main/packages/start/vite/plugin.js#L743))
I believe the assumption was that babel plugins shouldn't do anything if they've already transformed a file.
Perhaps this should be smarter and not produce the `insertCode` at all if it's already present in the file, but this simple `??=` fix has been tested and works. There is duplicate/redundant code that's generated, but it's only in development, so 🤷