### PR TITLE
Fixed URL for VSCode

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,7 +13,7 @@ export type Targets = { [k: string]: Target };
 
 export const allTargets: Targets = {
   vscode: {
-    url: "vscode://file/${projectPath}${filePath}:${line}:${column}",
+    url: "vscode://file${projectPath}${filePath}:${line}:${column}",
     label: "VSCode",
   },
   webstorm: {


### PR DESCRIPTION
## Summary of the PR
This PR addresses the issue reported on GitHub: [GitHub Issue Link](https://github.com/infi-pc/locatorjs/issues/127#issuecomment-1801180366). It aims to fix a problem that occurred after a new VS Code update, which prevented opening React components in VS Code from the browser. The solution involves changes to the `Index.ts` file.

## Changes Made
In the `Index.ts` file, modifications were made to the `allTargets` object. Specifically, changes were made to the URLs for VS Code and WebStorm. Here is the code snippet with the modifications:

```javascript
export const allTargets: Targets = {
  vscode: {
    url: "vscode://file${projectPath}${filePath}:${line}:${column}", // Old url vscode://file/${projectPath}${filePath}:${line}:${column}
    label: "VSCode",
  },
  webstorm: {
    url: "webstorm://open?file=${projectPath}${filePath}&line=${line}&column=${column}",
    label: "WebStorm",
  },
};
