### PR TITLE
Option overrides for runtime package

### DIFF
--- a/packages/runtime/src/components/Runtime.tsx
+++ b/packages/runtime/src/components/Runtime.tsx
@@ -1,4 +1,4 @@
-import { detectSvelte, Targets } from "@locator/shared";
+import { detectSvelte, ProjectOptions, Targets } from "@locator/shared";
 import { batch, createEffect, createSignal, onCleanup, Show } from "solid-js";
 import { render } from "solid-js/web";
 import { AdapterId } from "../consts";
@@ -431,11 +431,12 @@ function RuntimeWrapper(props: RuntimeProps) {
 export function initRender(
   solidLayer: HTMLDivElement,
   adapter: AdapterId | undefined,
-  targets: SetupTargets
+  targets: SetupTargets,
+  optionOverrides?: ProjectOptions,
 ) {
   render(
     () => (
-      <OptionsProvider>
+      <OptionsProvider optionOverrides={optionOverrides}>
         <RuntimeWrapper
           targets={Object.fromEntries(
             Object.entries(targets).map(([key, t]) => {

--- a/packages/runtime/src/functions/optionsStore.tsx
+++ b/packages/runtime/src/functions/optionsStore.tsx
@@ -11,8 +11,9 @@ export type OptionsStore = {
   getOptions: () => ProjectOptions;
 };
 
-export function initOptions(): OptionsStore {
+export function initOptions(optionOverrides?: ProjectOptions): OptionsStore {
   const [signalOptions, setSignalOptions] = createSignal(getStoredOptions());
+  if (optionOverrides) setSignalOptions({...signalOptions(), ...optionOverrides});
 
   // This listens on localStorage changes, but the changes go only from scripts other than the current one and current one's content scripts
   listenOnOptionsChanges((newOptions) => {
@@ -57,8 +58,8 @@ export function initOptions(): OptionsStore {
 
 const OptionsContext = createContext<OptionsStore>();
 
-export function OptionsProvider(props: { children: any }) {
-  const options = initOptions();
+export function OptionsProvider(props: { children: any, optionOverrides?: ProjectOptions}) {
+  const options = initOptions(props.optionOverrides);
 
   return (
     <OptionsContext.Provider value={options}>

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,4 @@
-import { Target } from "@locator/shared";
+import { ProjectOptions, Target } from "@locator/shared";
 import { AdapterId } from "./consts";
 import { initRuntime } from "./initRuntime";
 import { isExtension } from "./functions/isExtension";
@@ -15,13 +15,15 @@ export function setup({
   adapter,
   targets,
   projectPath,
+  optionOverrides,
 }: {
   adapter?: AdapterId;
   // defaultMode?: LocatorJSMode;
   targets?: { [k: string]: Target | string };
   projectPath?: string;
+  optionOverrides?: ProjectOptions;
 } = {}) {
-  setTimeout(() => initRuntime({ adapter, targets, projectPath }), 0);
+  setTimeout(() => initRuntime({ adapter, targets, projectPath, optionOverrides }), 0);
 }
 
 export default setup;

--- a/packages/runtime/src/initRuntime.ts
+++ b/packages/runtime/src/initRuntime.ts
@@ -1,4 +1,4 @@
-import { allTargets, Target } from "@locator/shared";
+import { allTargets, ProjectOptions, Target } from "@locator/shared";
 import { AdapterId, fontFamily } from "./consts";
 import generatedStyles from "./_generated_styles";
 import { MAX_ZINDEX } from "./index";
@@ -8,10 +8,12 @@ export function initRuntime({
   adapter,
   targets,
   projectPath,
+  optionOverrides,
 }: {
   adapter?: AdapterId;
   targets?: { [k: string]: Target | string };
   projectPath?: string;
+  optionOverrides?: ProjectOptions;
 } = {}) {
   if (typeof window === "undefined" || typeof document === "undefined") {
     return;
@@ -82,10 +84,10 @@ export function initRuntime({
   if (typeof require !== "undefined") {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { initRender } = require("./components/Runtime");
-    initRender(layer, adapter, targets || allTargets);
+    initRender(layer, adapter, targets || allTargets, optionOverrides);
   } else {
     import("./components/Runtime").then(({ initRender }) => {
-      initRender(layer, adapter, targets || allTargets);
+      initRender(layer, adapter, targets || allTargets, optionOverrides);
     });
   }
 }


### PR DESCRIPTION
Added a new parameter to setupLocatorUI, that allows us to override the options. 
I think this is only needed for some cases where people have many projects that use the same port.
Should solve #141