### PR TITLE
Fix: Add backslash to resolve VSCode path issue after latest update

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -13,7 +13,7 @@ export type Targets = { [k: string]: Target };
 
 export const allTargets: Targets = {
   vscode: {
-    url: "vscode://file${projectPath}${filePath}:${line}:${column}",
+    url: "vscode://file/${projectPath}${filePath}:${line}:${column}",
     label: "VSCode",
   },
   webstorm: {


### PR DESCRIPTION
### Summary of the PR
This pull request addresses an issue #149 that arose after the latest VS Code update, which disrupted the ability to open React components directly in VS Code from the browser. The previous solution(#129), which removed a backslash from the URL structure, no longer functions as intended after the update. This PR reintroduces the backslash to restore the original functionality. The changes are made to the `Index.ts` file within the `allTargets` object.

### Changes
![image](https://github.com/user-attachments/assets/af989e73-a80b-4934-a69a-38388173f72a)
