### PR TITLE
feat: add Cursor and Windsurf editor support

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -20,6 +20,14 @@ export const allTargets: Targets = {
     url: "webstorm://open?file=${projectPath}${filePath}&line=${line}&column=${column}",
     label: "WebStorm",
   },
+  cursor: {
+    url: "cursor://file/${projectPath}${filePath}:${line}:${column}",
+    label: "Cursor",
+  },
+  windsurf: {
+    url: "windsurf://file/${projectPath}${filePath}:${line}:${column}",
+    label: "Windsurf",
+  },
 };
 
 export const isMac =


### PR DESCRIPTION
## Description
- Both Windsurf and Cursor can be configured through custom links, but considering their recent surge in adoption, adding native support to the default editor list would improve developer experience and reduce setup friction.
- Added URL handlers for Cursor and Windsurf editors to the targets list, allowing users to open files directly in these editors.

## Issues:
- https://github.com/infi-pc/locatorjs/issues/104
- https://github.com/infi-pc/locatorjs/issues/166