### PR TITLE
Rework PR #199: React 19/Turbopack support

### DIFF
--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -28,12 +28,124 @@ When I click on a component's bounding box, it doesn't go to editor
 
 - It is possible that your editor doesn't have registered URL handler. Check browser console for errors. If you get something like `Failed to launch 'vscode://...24:11' because the scheme does not have a registered handler.`, try reinstalling your editor.
 
-# Run extension locally
+## Debug Mode
 
-run `pnpm dev` for development.
-run `pnpm build` to build the extension.
+如果遇到跳转位置不正确或跳转报错的问题，可以启用 Debug 模式来排查：
+
+### 启用方式
+
+1. **设置面板开关**（推荐）：点击 LocatorJS 图标打开设置，开启 "Debug Mode" 开关
+2. **控制台命令**：`window.__LOCATORJS_DEBUG__ = true` 或 `enableLocatorDebug()`
+
+### 控制台输出
+
+启用后，点击元素时控制台会显示：
+
+```
+[LocatorJS] 开始定位源码
+  Fiber: <div> (tag: 5)
+  DOM 元素: <div class="xxx">...</div>
+
+[LocatorJS] [同步] 源码定位成功
+  方式: fiber._debugSource
+  组件: <div>
+  位置: /app/page.tsx:15:0
+
+[LocatorJS] ✅ 定位完成
+  最终方式: fiber._debugSource
+  目标位置: /app/page.tsx:15:0
+```
+
+### 支持的定位方式
+
+| 类型 | 方式 |
+|------|------|
+| 同步 | `fiber._debugSource`、`elementType._source`、`type._source`、`memoizedProps.__source`、`_debugInfo` |
+| 异步 | `rendererInterfaces API` (React DevTools 7.0.1+)、`Turbopack chunk`、`source-map` 反查 |
+
+### 查看历史记录
+
+```javascript
+window.__LOCATORJS_DEBUG_HISTORY__
+```
+
+# Development
+
+## Run extension locally
+
+```bash
+# 开发模式（Chrome）
+pnpm dev
+
+# 开发模式（Firefox）
+pnpm dev:firefox
+```
+
+## Build & Release
+
+### 使用 Node 脚本（推荐）
+
+```bash
+# 打包 Chrome 版本（自动构建依赖 + 扩展 + zip）
+pnpm run release:node
+
+# 打包 Firefox 版本
+pnpm run release:node:firefox
+
+# 打包所有版本
+pnpm run release:node:all
+
+# 跳过依赖构建（仅重新打包扩展）
+node utils/release.js --skip-runtime
+```
+
+### 分步构建
+
+```bash
+# 1. 构建依赖包（按顺序）
+cd ../../packages/shared && pnpm build && cd -
+cd ../../packages/runtime && pnpm build && cd -
+
+# 2. 构建扩展
+pnpm build              # Chrome
+pnpm build:firefox      # Firefox
+
+# 3. 打包 zip
+pnpm pack:chrome        # -> build/chrome.zip
+pnpm pack:firefox       # -> build/artifacts_firefox/
+```
+
+### 构建注意事项
+
+- **包依赖顺序**：`shared` → `runtime` → `extension`
+- 修改 `shared` 包类型定义后，需要先构建 `shared`，再构建 `runtime`
+- TypeScript 类型错误可能是因为依赖包未重新构建，实际构建时会正常工作
+
+### 产物位置
+
+| 版本 | 构建目录 | 打包文件 |
+|------|----------|----------|
+| Chrome | `build/production_chrome/` | `build/chrome.zip` |
+| Firefox | `build/production_firefox/` | `build/artifacts_firefox/*.zip` |
+
+## Load unpacked extension
+
+**Chrome:**
+1. 打开 `chrome://extensions/`
+2. 开启「开发者模式」
+3. 点击「加载已解压的扩展程序」
+4. 选择 `build/production_chrome` 目录
+
+**Firefox:**
+1. 打开 `about:debugging#/runtime/this-firefox`
+2. 点击「临时载入附加组件」
+3. 选择 `build/production_firefox/manifest.json`
 
 # Contributing
 
 To develop of contribute to this project [continue here](./../../contributing.md)
+构建扩展：
+<!-- cd apps/extension && pnpm run release:chrome -->
 
+debug:
+ window.__LOCATORJS_DEBUG__ = true

--- a/apps/extension/README.md
+++ b/apps/extension/README.md
@@ -30,40 +30,40 @@ When I click on a component's bounding box, it doesn't go to editor
 
 ## Debug Mode
 
-如果遇到跳转位置不正确或跳转报错的问题，可以启用 Debug 模式来排查：
+If source locations are incorrect or navigation fails, enable Debug Mode to troubleshoot:
 
-### 启用方式
+### How to enable
 
-1. **设置面板开关**（推荐）：点击 LocatorJS 图标打开设置，开启 "Debug Mode" 开关
-2. **控制台命令**：`window.__LOCATORJS_DEBUG__ = true` 或 `enableLocatorDebug()`
+1. **Settings panel** (recommended): Click the LocatorJS icon, open settings, and toggle "Debug Mode" on
+2. **Console command**: `window.__LOCATORJS_DEBUG__ = true` or `enableLocatorDebug()`
 
-### 控制台输出
+### Console output
 
-启用后，点击元素时控制台会显示：
+When enabled, clicking an element will log resolution details to the console:
 
 ```
-[LocatorJS] 开始定位源码
+[LocatorJS] Starting source resolution
   Fiber: <div> (tag: 5)
-  DOM 元素: <div class="xxx">...</div>
+  DOM element: <div class="xxx">...</div>
 
-[LocatorJS] [同步] 源码定位成功
-  方式: fiber._debugSource
-  组件: <div>
-  位置: /app/page.tsx:15:0
+[LocatorJS] [sync] Source found
+  Method: fiber._debugSource
+  Component: <div>
+  Location: /app/page.tsx:15:0
 
-[LocatorJS] ✅ 定位完成
-  最终方式: fiber._debugSource
-  目标位置: /app/page.tsx:15:0
+[LocatorJS] Location complete
+  Final method: fiber._debugSource
+  Target location: /app/page.tsx:15:0
 ```
 
-### 支持的定位方式
+### Supported resolution methods
 
-| 类型 | 方式 |
-|------|------|
-| 同步 | `fiber._debugSource`、`elementType._source`、`type._source`、`memoizedProps.__source`、`_debugInfo` |
-| 异步 | `rendererInterfaces API` (React DevTools 7.0.1+)、`Turbopack chunk`、`source-map` 反查 |
+| Type | Methods |
+|------|---------|
+| Sync | `fiber._debugSource`, `elementType._source`, `type._source`, `memoizedProps.__source`, `_debugInfo` |
+| Async | `rendererInterfaces API` (React DevTools 7.0.1+), `Turbopack chunk`, `source-map` reverse lookup |
 
-### 查看历史记录
+### View debug history
 
 ```javascript
 window.__LOCATORJS_DEBUG_HISTORY__
@@ -74,78 +74,73 @@ window.__LOCATORJS_DEBUG_HISTORY__
 ## Run extension locally
 
 ```bash
-# 开发模式（Chrome）
+# Development mode (Chrome)
 pnpm dev
 
-# 开发模式（Firefox）
+# Development mode (Firefox)
 pnpm dev:firefox
 ```
 
 ## Build & Release
 
-### 使用 Node 脚本（推荐）
+### Using Node script (recommended)
 
 ```bash
-# 打包 Chrome 版本（自动构建依赖 + 扩展 + zip）
+# Package Chrome version (builds deps + extension + zip)
 pnpm run release:node
 
-# 打包 Firefox 版本
+# Package Firefox version
 pnpm run release:node:firefox
 
-# 打包所有版本
+# Package all versions
 pnpm run release:node:all
 
-# 跳过依赖构建（仅重新打包扩展）
+# Skip dependency build (re-package extension only)
 node utils/release.js --skip-runtime
 ```
 
-### 分步构建
+### Step-by-step build
 
 ```bash
-# 1. 构建依赖包（按顺序）
+# 1. Build dependency packages (in order)
 cd ../../packages/shared && pnpm build && cd -
 cd ../../packages/runtime && pnpm build && cd -
 
-# 2. 构建扩展
+# 2. Build extension
 pnpm build              # Chrome
 pnpm build:firefox      # Firefox
 
-# 3. 打包 zip
+# 3. Package zip
 pnpm pack:chrome        # -> build/chrome.zip
 pnpm pack:firefox       # -> build/artifacts_firefox/
 ```
 
-### 构建注意事项
+### Build notes
 
-- **包依赖顺序**：`shared` → `runtime` → `extension`
-- 修改 `shared` 包类型定义后，需要先构建 `shared`，再构建 `runtime`
-- TypeScript 类型错误可能是因为依赖包未重新构建，实际构建时会正常工作
+- **Package build order**: `shared` -> `runtime` -> `extension`
+- After modifying `shared` type definitions, rebuild `shared` first, then `runtime`
+- TypeScript type errors may occur if dependency packages haven't been rebuilt; the actual build will work correctly
 
-### 产物位置
+### Build output
 
-| 版本 | 构建目录 | 打包文件 |
-|------|----------|----------|
+| Version | Build directory | Package file |
+|---------|----------------|--------------|
 | Chrome | `build/production_chrome/` | `build/chrome.zip` |
 | Firefox | `build/production_firefox/` | `build/artifacts_firefox/*.zip` |
 
 ## Load unpacked extension
 
 **Chrome:**
-1. 打开 `chrome://extensions/`
-2. 开启「开发者模式」
-3. 点击「加载已解压的扩展程序」
-4. 选择 `build/production_chrome` 目录
+1. Open `chrome://extensions/`
+2. Enable "Developer mode"
+3. Click "Load unpacked"
+4. Select the `build/production_chrome` directory
 
 **Firefox:**
-1. 打开 `about:debugging#/runtime/this-firefox`
-2. 点击「临时载入附加组件」
-3. 选择 `build/production_firefox/manifest.json`
+1. Open `about:debugging#/runtime/this-firefox`
+2. Click "Load Temporary Add-on"
+3. Select `build/production_firefox/manifest.json`
 
 # Contributing
 
 To develop of contribute to this project [continue here](./../../contributing.md)
-构建扩展：
-<!-- cd apps/extension && pnpm run release:chrome -->
-
-debug:
- window.__LOCATORJS_DEBUG__ = true

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "locatorjs-extension",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "LocatorJS Chrome Extension - option-click to code (ReactJS)",
   "license": "MIT",
   "repository": {
@@ -10,12 +10,20 @@
   "scripts": {
     "build": "node utils/build.js",
     "build:firefox": "TARGET_BROWSER=firefox node utils/build.js",
+    "build:all": "run-s build build:firefox",
     "lint": "eslint src --ext .ts,.tsx",
     "dev": "node utils/webserver.js",
     "dev:firefox": "TARGET_BROWSER=firefox node utils/webserver.js",
     "start:firefox": "web-ext run --source-dir ./build/production_firefox",
+    "pack:chrome": "cd ./build/production_chrome && zip -r ../chrome.zip .",
     "pack:firefox": "web-ext build --source-dir ./build/production_firefox --artifacts-dir ./build/artifacts_firefox",
-    "pack:chrome": "cd ./build/production_chrome && zip -r ../../build/chrome.zip .",
+    "pack:all": "run-s pack:chrome pack:firefox",
+    "release:chrome": "run-s build pack:chrome",
+    "release:firefox": "run-s build:firefox pack:firefox",
+    "release": "run-s build:all pack:all",
+    "release:node": "node utils/release.js",
+    "release:node:firefox": "node utils/release.js --firefox",
+    "release:node:all": "node utils/release.js --all",
     "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,scss,md}'"
   },
   "dependencies": {

--- a/apps/extension/utils/build.js
+++ b/apps/extension/utils/build.js
@@ -3,6 +3,11 @@ process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
 process.env.ASSET_PATH = '/';
 
+// 手动设置 npm_package_* 环境变量（直接调用 node 时不会自动设置）
+var pkg = require('../package.json');
+process.env.npm_package_version = pkg.version;
+process.env.npm_package_description = pkg.description;
+
 var webpack = require('webpack'),
   config = require('../webpack.config');
 
@@ -10,6 +15,21 @@ delete config.chromeExtensionBoilerplate;
 
 config.mode = 'production';
 
-webpack(config, function (err) {
-  if (err) throw err;
+webpack(config, function (err, stats) {
+  if (err) {
+    console.error(err.stack || err);
+    if (err.details) {
+      console.error(err.details);
+    }
+    return;
+  }
+
+  const info = stats.toJson();
+  if (stats.hasErrors()) {
+    console.error(info.errors);
+  }
+  if (stats.hasWarnings()) {
+    console.warn(info.warnings);
+  }
+  console.log(stats.toString({ colors: true }));
 });

--- a/apps/extension/utils/build.js
+++ b/apps/extension/utils/build.js
@@ -3,7 +3,7 @@ process.env.BABEL_ENV = 'production';
 process.env.NODE_ENV = 'production';
 process.env.ASSET_PATH = '/';
 
-// 手动设置 npm_package_* 环境变量（直接调用 node 时不会自动设置）
+// Manually set npm_package_* env vars (not auto-set when calling node directly)
 var pkg = require('../package.json');
 process.env.npm_package_version = pkg.version;
 process.env.npm_package_description = pkg.description;

--- a/apps/extension/utils/release.js
+++ b/apps/extension/utils/release.js
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
 
 /**
- * Chrome 扩展打包脚本
- * 完整流程：构建依赖 -> 构建扩展 -> 打包 zip
+ * Chrome extension packaging script
+ * Full pipeline: build deps -> build extension -> package zip
  *
- * 用法：
- *   node utils/release.js           # 打包 Chrome 版本
- *   node utils/release.js --firefox # 打包 Firefox 版本
- *   node utils/release.js --all     # 打包所有版本
+ * Usage:
+ *   node utils/release.js           # Package Chrome version
+ *   node utils/release.js --firefox # Package Firefox version
+ *   node utils/release.js --all     # Package all versions
  */
 
 const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs-extra");
 
-// archiver 可选，没有则 fallback 到系统 zip 命令
+// archiver is optional, falls back to system zip command
 let archiver;
 try {
   archiver = require("archiver");
@@ -22,13 +22,13 @@ try {
   archiver = null;
 }
 
-// 路径配置
+// Path configuration
 const ROOT_DIR = path.resolve(__dirname, "../../..");
 const EXTENSION_DIR = path.resolve(__dirname, "..");
 const RUNTIME_DIR = path.resolve(ROOT_DIR, "packages/runtime");
 const BUILD_DIR = path.resolve(EXTENSION_DIR, "build");
 
-// 颜色输出
+// Color output
 const colors = {
   reset: "\x1b[0m",
   bright: "\x1b[1m",
@@ -55,7 +55,7 @@ function logError(message) {
 }
 
 /**
- * 执行命令并实时输出
+ * Execute a command with real-time output
  */
 function execCommand(command, options = {}) {
   const { cwd = process.cwd(), silent = false } = options;
@@ -92,28 +92,28 @@ function execCommand(command, options = {}) {
 }
 
 /**
- * 构建 runtime 包
+ * Build the runtime package
  */
 async function buildRuntime() {
-  logStep(1, "构建 @locator/runtime 包...");
+  logStep(1, "Building @locator/runtime package...");
 
   await execCommand("pnpm run build", { cwd: RUNTIME_DIR });
-  logSuccess("runtime 构建完成");
+  logSuccess("Runtime build complete");
 }
 
 /**
- * 构建扩展
+ * Build the extension
  */
 async function buildExtension(target = "chrome") {
-  logStep(2, `构建 ${target} 扩展...`);
+  logStep(2, `Building ${target} extension...`);
 
   const buildCmd = target === "firefox" ? "pnpm run build:firefox" : "pnpm run build";
   await execCommand(buildCmd, { cwd: EXTENSION_DIR });
-  logSuccess(`${target} 扩展构建完成`);
+  logSuccess(`${target} extension build complete`);
 }
 
 /**
- * 使用 archiver 打包 zip（纯 Node.js 实现）
+ * Create zip using archiver (pure Node.js)
  */
 async function createZipWithArchiver(sourceDir, outputPath) {
   return new Promise((resolve, reject) => {
@@ -133,7 +133,7 @@ async function createZipWithArchiver(sourceDir, outputPath) {
 }
 
 /**
- * 使用系统 zip 命令打包
+ * Create zip using system zip command
  */
 async function createZipWithSystem(sourceDir, outputPath) {
   await execCommand(`cd "${sourceDir}" && zip -r "${outputPath}" .`);
@@ -142,25 +142,25 @@ async function createZipWithSystem(sourceDir, outputPath) {
 }
 
 /**
- * 打包成 zip
+ * Package the extension into a zip
  */
 async function packExtension(target = "chrome") {
-  logStep(3, `打包 ${target}.zip...`);
+  logStep(3, `Packaging ${target}.zip...`);
 
   const sourceDir = path.join(BUILD_DIR, `production_${target}`);
   const outputPath = path.join(BUILD_DIR, `${target}.zip`);
 
-  // 确保源目录存在
+  // Ensure source directory exists
   if (!fs.existsSync(sourceDir)) {
-    throw new Error(`构建目录不存在: ${sourceDir}`);
+    throw new Error(`Build directory does not exist: ${sourceDir}`);
   }
 
-  // 删除旧的 zip
+  // Remove old zip
   if (fs.existsSync(outputPath)) {
     fs.removeSync(outputPath);
   }
 
-  // 使用 archiver 或 fallback 到系统 zip 命令
+  // Use archiver or fall back to system zip command
   let size;
   if (archiver) {
     size = await createZipWithArchiver(sourceDir, outputPath);
@@ -168,12 +168,12 @@ async function packExtension(target = "chrome") {
     size = await createZipWithSystem(sourceDir, outputPath);
   }
 
-  logSuccess(`打包完成: ${outputPath} (${size}KB)`);
+  logSuccess(`Packaging complete: ${outputPath} (${size}KB)`);
   return outputPath;
 }
 
 /**
- * 获取版本信息
+ * Get version info from package.json
  */
 function getVersionInfo() {
   const pkg = require(path.join(EXTENSION_DIR, "package.json"));
@@ -184,7 +184,7 @@ function getVersionInfo() {
 }
 
 /**
- * 主流程
+ * Main entry point
  */
 async function main() {
   const args = process.argv.slice(2);
@@ -196,50 +196,50 @@ async function main() {
   const { version, name } = getVersionInfo();
 
   log(`\n${"=".repeat(50)}`, "bright");
-  log(`  ${name} v${version} 打包脚本`, "bright");
+  log(`  ${name} v${version} release script`, "bright");
   log(`${"=".repeat(50)}`, "bright");
 
   try {
-    // 1. 构建依赖
+    // 1. Build dependencies
     if (!skipRuntime) {
       await buildRuntime();
     } else {
-      log("\n[跳过] runtime 构建", "yellow");
+      log("\n[Skipped] runtime build", "yellow");
     }
 
     const outputs = [];
 
-    // 2. 构建和打包
+    // 2. Build and package
     if (buildAll) {
-      // 构建所有版本
+      // Build all versions
       await buildExtension("chrome");
       outputs.push(await packExtension("chrome"));
 
       await buildExtension("firefox");
       outputs.push(await packExtension("firefox"));
     } else if (buildFirefox) {
-      // 仅 Firefox
+      // Firefox only
       await buildExtension("firefox");
       outputs.push(await packExtension("firefox"));
     } else {
-      // 默认 Chrome
+      // Default: Chrome
       await buildExtension("chrome");
       outputs.push(await packExtension("chrome"));
     }
 
-    // 完成
+    // Done
     const duration = ((Date.now() - startTime) / 1000).toFixed(1);
     log(`\n${"=".repeat(50)}`, "green");
-    log(`  打包完成! 耗时 ${duration}s`, "green");
+    log(`  Packaging complete! Time elapsed: ${duration}s`, "green");
     log(`${"=".repeat(50)}`, "green");
-    log("\n产物:");
+    log("\nArtifacts:");
     outputs.forEach((p) => log(`  - ${p}`));
     log("");
   } catch (error) {
-    logError(`打包失败: ${error.message}`);
+    logError(`Packaging failed: ${error.message}`);
     process.exit(1);
   }
 }
 
-// 运行
+// Run
 main();

--- a/apps/extension/utils/release.js
+++ b/apps/extension/utils/release.js
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+
+/**
+ * Chrome 扩展打包脚本
+ * 完整流程：构建依赖 -> 构建扩展 -> 打包 zip
+ *
+ * 用法：
+ *   node utils/release.js           # 打包 Chrome 版本
+ *   node utils/release.js --firefox # 打包 Firefox 版本
+ *   node utils/release.js --all     # 打包所有版本
+ */
+
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs-extra");
+
+// archiver 可选，没有则 fallback 到系统 zip 命令
+let archiver;
+try {
+  archiver = require("archiver");
+} catch {
+  archiver = null;
+}
+
+// 路径配置
+const ROOT_DIR = path.resolve(__dirname, "../../..");
+const EXTENSION_DIR = path.resolve(__dirname, "..");
+const RUNTIME_DIR = path.resolve(ROOT_DIR, "packages/runtime");
+const BUILD_DIR = path.resolve(EXTENSION_DIR, "build");
+
+// 颜色输出
+const colors = {
+  reset: "\x1b[0m",
+  bright: "\x1b[1m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  red: "\x1b[31m",
+};
+
+function log(message, color = "reset") {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function logStep(step, message) {
+  log(`\n[$${step}] ${message}`, "blue");
+}
+
+function logSuccess(message) {
+  log(`✓ ${message}`, "green");
+}
+
+function logError(message) {
+  log(`✗ ${message}`, "red");
+}
+
+/**
+ * 执行命令并实时输出
+ */
+function execCommand(command, options = {}) {
+  const { cwd = process.cwd(), silent = false } = options;
+
+  return new Promise((resolve, reject) => {
+    if (!silent) {
+      log(`  > ${command}`, "yellow");
+    }
+
+    const child = spawn(command, {
+      cwd,
+      shell: true,
+      stdio: silent ? "pipe" : "inherit",
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    if (silent) {
+      child.stdout?.on("data", (data) => (stdout += data));
+      child.stderr?.on("data", (data) => (stderr += data));
+    }
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+      } else {
+        reject(new Error(`Command failed with code ${code}: ${command}`));
+      }
+    });
+
+    child.on("error", reject);
+  });
+}
+
+/**
+ * 构建 runtime 包
+ */
+async function buildRuntime() {
+  logStep(1, "构建 @locator/runtime 包...");
+
+  await execCommand("pnpm run build", { cwd: RUNTIME_DIR });
+  logSuccess("runtime 构建完成");
+}
+
+/**
+ * 构建扩展
+ */
+async function buildExtension(target = "chrome") {
+  logStep(2, `构建 ${target} 扩展...`);
+
+  const buildCmd = target === "firefox" ? "pnpm run build:firefox" : "pnpm run build";
+  await execCommand(buildCmd, { cwd: EXTENSION_DIR });
+  logSuccess(`${target} 扩展构建完成`);
+}
+
+/**
+ * 使用 archiver 打包 zip（纯 Node.js 实现）
+ */
+async function createZipWithArchiver(sourceDir, outputPath) {
+  return new Promise((resolve, reject) => {
+    const output = fs.createWriteStream(outputPath);
+    const archive = archiver("zip", { zlib: { level: 9 } });
+
+    output.on("close", () => {
+      const size = (archive.pointer() / 1024).toFixed(1);
+      resolve(size);
+    });
+
+    archive.on("error", reject);
+    archive.pipe(output);
+    archive.directory(sourceDir, false);
+    archive.finalize();
+  });
+}
+
+/**
+ * 使用系统 zip 命令打包
+ */
+async function createZipWithSystem(sourceDir, outputPath) {
+  await execCommand(`cd "${sourceDir}" && zip -r "${outputPath}" .`);
+  const stats = fs.statSync(outputPath);
+  return (stats.size / 1024).toFixed(1);
+}
+
+/**
+ * 打包成 zip
+ */
+async function packExtension(target = "chrome") {
+  logStep(3, `打包 ${target}.zip...`);
+
+  const sourceDir = path.join(BUILD_DIR, `production_${target}`);
+  const outputPath = path.join(BUILD_DIR, `${target}.zip`);
+
+  // 确保源目录存在
+  if (!fs.existsSync(sourceDir)) {
+    throw new Error(`构建目录不存在: ${sourceDir}`);
+  }
+
+  // 删除旧的 zip
+  if (fs.existsSync(outputPath)) {
+    fs.removeSync(outputPath);
+  }
+
+  // 使用 archiver 或 fallback 到系统 zip 命令
+  let size;
+  if (archiver) {
+    size = await createZipWithArchiver(sourceDir, outputPath);
+  } else {
+    size = await createZipWithSystem(sourceDir, outputPath);
+  }
+
+  logSuccess(`打包完成: ${outputPath} (${size}KB)`);
+  return outputPath;
+}
+
+/**
+ * 获取版本信息
+ */
+function getVersionInfo() {
+  const pkg = require(path.join(EXTENSION_DIR, "package.json"));
+  return {
+    version: pkg.version,
+    name: pkg.name,
+  };
+}
+
+/**
+ * 主流程
+ */
+async function main() {
+  const args = process.argv.slice(2);
+  const buildFirefox = args.includes("--firefox");
+  const buildAll = args.includes("--all");
+  const skipRuntime = args.includes("--skip-runtime");
+
+  const startTime = Date.now();
+  const { version, name } = getVersionInfo();
+
+  log(`\n${"=".repeat(50)}`, "bright");
+  log(`  ${name} v${version} 打包脚本`, "bright");
+  log(`${"=".repeat(50)}`, "bright");
+
+  try {
+    // 1. 构建依赖
+    if (!skipRuntime) {
+      await buildRuntime();
+    } else {
+      log("\n[跳过] runtime 构建", "yellow");
+    }
+
+    const outputs = [];
+
+    // 2. 构建和打包
+    if (buildAll) {
+      // 构建所有版本
+      await buildExtension("chrome");
+      outputs.push(await packExtension("chrome"));
+
+      await buildExtension("firefox");
+      outputs.push(await packExtension("firefox"));
+    } else if (buildFirefox) {
+      // 仅 Firefox
+      await buildExtension("firefox");
+      outputs.push(await packExtension("firefox"));
+    } else {
+      // 默认 Chrome
+      await buildExtension("chrome");
+      outputs.push(await packExtension("chrome"));
+    }
+
+    // 完成
+    const duration = ((Date.now() - startTime) / 1000).toFixed(1);
+    log(`\n${"=".repeat(50)}`, "green");
+    log(`  打包完成! 耗时 ${duration}s`, "green");
+    log(`${"=".repeat(50)}`, "green");
+    log("\n产物:");
+    outputs.forEach((p) => log(`  - ${p}`));
+    log("");
+  } catch (error) {
+    logError(`打包失败: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+// 运行
+main();

--- a/apps/next-16-turbopack/app/ClientProviders.tsx
+++ b/apps/next-16-turbopack/app/ClientProviders.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import setupLocatorUI from "@locator/runtime";
+
+if (process.env.NODE_ENV === "development") {
+  setupLocatorUI();
+}
+
+export default function ClientProviders({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/apps/next-16-turbopack/app/components/Card.tsx
+++ b/apps/next-16-turbopack/app/components/Card.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+export default function Card({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        border: "1px solid #ddd",
+        borderRadius: "8px",
+        padding: "1rem",
+        marginBottom: "1rem",
+      }}
+    >
+      <h3 style={{ marginBottom: "0.5rem" }}>{title}</h3>
+      {children}
+    </div>
+  );
+}

--- a/apps/next-16-turbopack/app/components/Counter.tsx
+++ b/apps/next-16-turbopack/app/components/Counter.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState } from "react";
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+      <button
+        onClick={() => setCount((c) => c - 1)}
+        style={{ padding: "0.25rem 0.75rem" }}
+      >
+        -
+      </button>
+      <span style={{ minWidth: "2rem", textAlign: "center" }}>{count}</span>
+      <button
+        onClick={() => setCount((c) => c + 1)}
+        style={{ padding: "0.25rem 0.75rem" }}
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/apps/next-16-turbopack/app/globals.css
+++ b/apps/next-16-turbopack/app/globals.css
@@ -1,0 +1,11 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  padding: 2rem;
+  color: #333;
+}

--- a/apps/next-16-turbopack/app/layout.tsx
+++ b/apps/next-16-turbopack/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import ClientProviders from "./ClientProviders";
+
+export const metadata: Metadata = {
+  title: "LocatorJS - React 19 Turbopack Test",
+  description: "Testing native source resolution without webpack-loader",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>
+        <ClientProviders>{children}</ClientProviders>
+      </body>
+    </html>
+  );
+}

--- a/apps/next-16-turbopack/app/page.tsx
+++ b/apps/next-16-turbopack/app/page.tsx
@@ -1,0 +1,31 @@
+import Card from "./components/Card";
+import Counter from "./components/Counter";
+
+export default function Home() {
+  return (
+    <main>
+      <h1 style={{ marginBottom: "1.5rem" }}>
+        React 19 + Turbopack (no webpack-loader)
+      </h1>
+
+      <Card title="Counter Component">
+        <Counter />
+      </Card>
+
+      <Card title="Static Content">
+        <p>This is a paragraph inside a Card component.</p>
+        <ul>
+          <li>List item one</li>
+          <li>List item two</li>
+          <li>List item three</li>
+        </ul>
+      </Card>
+
+      <Card title="Nested Elements">
+        <div id="test-div" className="test-class">
+          <span>Nested span inside a div with className and id</span>
+        </div>
+      </Card>
+    </main>
+  );
+}

--- a/apps/next-16-turbopack/next-env.d.ts
+++ b/apps/next-16-turbopack/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/next-16-turbopack/next.config.ts
+++ b/apps/next-16-turbopack/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // No custom loaders — testing native React 19 source resolution
+};
+
+export default nextConfig;

--- a/apps/next-16-turbopack/package.json
+++ b/apps/next-16-turbopack/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "next-16-turbopack",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3353",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "next": "16.0.0"
+  },
+  "devDependencies": {
+    "@locator/runtime": "workspace:^",
+    "typescript": "^5",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19"
+  }
+}

--- a/apps/next-16-turbopack/tsconfig.json
+++ b/apps/next-16-turbopack/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/react-devtools-hook/tsconfig.json
+++ b/packages/react-devtools-hook/tsconfig.json
@@ -4,6 +4,7 @@
   "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
     "outDir": "dist",
+    "noEmit": false,
     "lib": ["ESNext", "dom"]
   }
 }

--- a/packages/runtime/src/_generated_styles.ts
+++ b/packages/runtime/src/_generated_styles.ts
@@ -808,6 +808,10 @@ select {
   left: 0px;
 }
 
+.left-0\\.5 {
+  left: 0.125rem;
+}
+
 .left-1 {
   left: 0.25rem;
 }
@@ -822,6 +826,10 @@ select {
 
 .top-0 {
   top: 0px;
+}
+
+.top-0\\.5 {
+  top: 0.125rem;
 }
 
 .top-1 {
@@ -930,6 +938,10 @@ select {
   height: 1rem;
 }
 
+.h-5 {
+  height: 1.25rem;
+}
+
 .h-6 {
   height: 1.5rem;
 }
@@ -960,6 +972,10 @@ select {
 
 .w-80 {
   width: 20rem;
+}
+
+.w-9 {
+  width: 2.25rem;
 }
 
 .w-96 {
@@ -1032,6 +1048,11 @@ select {
 
 .-translate-y-1\\/2 {
   --tw-translate-y: -50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-x-4 {
+  --tw-translate-x: 1rem;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
@@ -1168,6 +1189,11 @@ select {
   border-style: solid;
 }
 
+.border-amber-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(253 230 138 / var(--tw-border-opacity, 1));
+}
+
 .border-blue-500 {
   --tw-border-opacity: 1;
   border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
@@ -1216,6 +1242,16 @@ select {
 .border-slate-300 {
   --tw-border-opacity: 1;
   border-color: rgb(203 213 225 / var(--tw-border-opacity, 1));
+}
+
+.bg-amber-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 243 199 / var(--tw-bg-opacity, 1));
+}
+
+.bg-amber-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 251 235 / var(--tw-bg-opacity, 1));
 }
 
 .bg-black {
@@ -1470,6 +1506,10 @@ select {
   line-height: 2rem;
 }
 
+.text-\\[10px\\] {
+  font-size: 10px;
+}
+
 .text-base {
   font-size: 1rem;
   line-height: 1.5rem;
@@ -1504,6 +1544,25 @@ select {
 
 .lowercase {
   text-transform: lowercase;
+}
+
+.italic {
+  font-style: italic;
+}
+
+.text-amber-700 {
+  --tw-text-opacity: 1;
+  color: rgb(180 83 9 / var(--tw-text-opacity, 1));
+}
+
+.text-amber-800 {
+  --tw-text-opacity: 1;
+  color: rgb(146 64 14 / var(--tw-text-opacity, 1));
+}
+
+.text-amber-900 {
+  --tw-text-opacity: 1;
+  color: rgb(120 53 15 / var(--tw-text-opacity, 1));
 }
 
 .text-black {
@@ -1544,6 +1603,11 @@ select {
 .text-gray-700 {
   --tw-text-opacity: 1;
   color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+
+.text-gray-800 {
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-900 {
@@ -1619,6 +1683,11 @@ select {
 .text-slate-500 {
   --tw-text-opacity: 1;
   color: rgb(100 116 139 / var(--tw-text-opacity, 1));
+}
+
+.text-slate-600 {
+  --tw-text-opacity: 1;
+  color: rgb(71 85 105 / var(--tw-text-opacity, 1));
 }
 
 .text-slate-700 {
@@ -1713,8 +1782,20 @@ select {
   transition-duration: 150ms;
 }
 
+.transition-colors {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .transition-opacity {
   transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-transform {
+  transition-property: transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -1785,6 +1866,11 @@ select {
 .hover\\:text-gray-100:hover {
   --tw-text-opacity: 1;
   color: rgb(243 244 246 / var(--tw-text-opacity, 1));
+}
+
+.hover\\:text-indigo-800:hover {
+  --tw-text-opacity: 1;
+  color: rgb(55 48 163 / var(--tw-text-opacity, 1));
 }
 
 .hover\\:text-sky-900:hover {

--- a/packages/runtime/src/adapters/getElementInfo.tsx
+++ b/packages/runtime/src/adapters/getElementInfo.tsx
@@ -28,27 +28,27 @@ export function getElementInfo(target: HTMLElement, adapterId?: AdapterId) {
 }
 
 /**
- * 异步版本的 getElementInfo
- * 当同步方式无法获取 source 时，尝试通过 source-map 解析
- * 目前仅支持 React adapter
+ * Async version of getElementInfo
+ * When sync cannot get source, try source-map resolution
+ * Currently only supports React adapter
  */
 export async function getElementInfoAsync(
   target: HTMLElement,
   adapterId?: AdapterId
 ): Promise<FullElementInfo | null> {
-  // 先尝试同步方式
+  // Try synchronous method first
   const syncResult = getElementInfo(target, adapterId);
   if (syncResult && syncResult.thisElement.link) {
     return syncResult;
   }
 
-  // 同步方式无法获取 link，尝试异步方式（仅 React）
+  // Sync failed to get link, try async (React only)
   if (adapterId === "react" || !adapterId) {
     const asyncResult = await getReactElementInfoAsync(target);
     if (asyncResult && asyncResult.thisElement.link) {
       return asyncResult;
     }
-    // 如果异步也没有获取到 link，返回同步结果（至少有元素信息）
+    // If async also failed, return sync result (at least has element info)
     return asyncResult || syncResult;
   }
 

--- a/packages/runtime/src/adapters/getElementInfo.tsx
+++ b/packages/runtime/src/adapters/getElementInfo.tsx
@@ -1,8 +1,9 @@
-import reactAdapter from "./react/reactAdapter";
+import reactAdapter, { getElementInfoAsync as getReactElementInfoAsync } from "./react/reactAdapter";
 import jsxAdapter from "./jsx/jsxAdapter";
 import svelteAdapter from "./svelte/svelteAdapter";
 import vueAdapter from "./vue/vueAdapter";
 import { AdapterId } from "../consts";
+import { FullElementInfo } from "./adapterApi";
 
 export function getElementInfo(target: HTMLElement, adapterId?: AdapterId) {
   if (adapterId === "react") {
@@ -24,4 +25,32 @@ export function getElementInfo(target: HTMLElement, adapterId?: AdapterId) {
     svelteAdapter.getElementInfo(target) ||
     vueAdapter.getElementInfo(target)
   );
+}
+
+/**
+ * 异步版本的 getElementInfo
+ * 当同步方式无法获取 source 时，尝试通过 source-map 解析
+ * 目前仅支持 React adapter
+ */
+export async function getElementInfoAsync(
+  target: HTMLElement,
+  adapterId?: AdapterId
+): Promise<FullElementInfo | null> {
+  // 先尝试同步方式
+  const syncResult = getElementInfo(target, adapterId);
+  if (syncResult && syncResult.thisElement.link) {
+    return syncResult;
+  }
+
+  // 同步方式无法获取 link，尝试异步方式（仅 React）
+  if (adapterId === "react" || !adapterId) {
+    const asyncResult = await getReactElementInfoAsync(target);
+    if (asyncResult && asyncResult.thisElement.link) {
+      return asyncResult;
+    }
+    // 如果异步也没有获取到 link，返回同步结果（至少有元素信息）
+    return asyncResult || syncResult;
+  }
+
+  return syncResult;
 }

--- a/packages/runtime/src/adapters/react/clickSourceResolver.ts
+++ b/packages/runtime/src/adapters/react/clickSourceResolver.ts
@@ -167,7 +167,8 @@ async function getAllChunkCodes(): Promise<string[]> {
  * Search forward from attribute value position for fileName/lineNumber
  */
 function extractSourceNearPosition(code: string, position: number): Source | null {
-  // Search forward from current position for source info (within 1500 chars)
+  // Search forward for fileName/lineNumber in the jsxDEV call arguments.
+  // 1500 chars covers typical jsxDEV argument spans including props objects.
   const searchRange = code.slice(position, position + 1500);
   const fileMatch = searchRange.match(/fileName:\s*"([^"]+)"/);
   const lineMatch = searchRange.match(/lineNumber:\s*(\d+)/);
@@ -231,7 +232,8 @@ async function extractSourceFromTurbopackChunksForElement(
           const attrIndex = code.indexOf(`"${pattern}"`, searchIndex);
           if (attrIndex === -1) break;
 
-          // Search backward to confirm jsxDEV call (within 800 chars)
+          // Search backward to find the enclosing jsxDEV("tagName", ...) call.
+          // 800 chars covers the opening call + typical preceding props/children.
           const startRange = Math.max(0, attrIndex - 800);
           const beforeAttr = code.slice(startRange, attrIndex);
 
@@ -1123,10 +1125,5 @@ export function getSourceFromCache(fiber: Fiber): Source | null {
   return null;
 }
 
-/**
- * Clear component source cache
- */
-export function clearComponentSourceCache(): void {
-  // WeakMap cannot be cleared, would need to create a new one
-  // In practice, WeakMap automatically garbage-collects unreferenced keys
-}
+// Note: componentSourceCache is a WeakMap which auto-GCs when keys are dereferenced.
+// No explicit clear function is needed.

--- a/packages/runtime/src/adapters/react/clickSourceResolver.ts
+++ b/packages/runtime/src/adapters/react/clickSourceResolver.ts
@@ -9,39 +9,39 @@ import {
 } from "./debug";
 
 /**
- * 基于点击位置的 Source 解析器
- * 用于 Next.js 15+ / React 19+ 使用新打包工具的环境
+ * Click-based source resolver
+ * For Next.js 15+ / React 19+ environments with new bundlers
  *
- * 核心思路：
- * 1. 优先使用 React DevTools 7.0.1+ rendererInterfaces API
- * 2. 从 Fiber 获取组件 type（函数）
- * 3. 解析函数的 toString() 或相关元数据获取编译后位置
- * 4. 通过 source-map 反查原始位置
- * 5. 从 Turbopack chunk 代码中提取 jsxDEV 调用的 source 信息
+ * Strategy:
+ * 1. Prefer React DevTools 7.0.1+ rendererInterfaces API
+ * 2. Get component type (function) from Fiber
+ * 3. Parse function toString() or metadata for compiled location
+ * 4. Reverse-lookup original position via source-map
+ * 5. Extract source info from jsxDEV calls in Turbopack chunk code
  */
 
 /**
- * 扩展的 DevTools Hook 类型（兼容 7.0.1+）
+ * Extended DevTools Hook type (compatible with 7.0.1+)
  */
 type DevToolsHookWithInterfaces = {
   rendererInterfaces?: Map<number, RendererInterface>;
   renderers?: Map<number, unknown>;
 };
 
-// 缓存组件 type 到 source 的映射
+// Cache: component type -> source mapping
 const componentSourceCache = new WeakMap<object, Source | null>();
 
-// 缓存 chunk 代码，避免重复请求
+// Cache: chunk code to avoid repeated fetches
 const chunkCodeCache = new Map<string, string>();
 
-// 缓存组件名到 source 的映射（用于 Turbopack 方案）
+// Cache: component name -> source mapping (for Turbopack)
 const componentNameSourceCache = new Map<string, Source | null>();
 
-// 缓存元素签名到 source 的映射（用于原生元素）
+// Cache: element signature -> source mapping (for native elements)
 const elementSignatureSourceCache = new Map<string, Source | null>();
 
 /**
- * 获取所有 chunk 代码（带缓存）
+ * Get all chunk codes (with caching)
  */
 async function getAllChunkCodes(): Promise<string[]> {
   const scripts = Array.from(
@@ -70,11 +70,11 @@ async function getAllChunkCodes(): Promise<string[]> {
 }
 
 /**
- * 在 chunk 代码中搜索 source 信息（通用方法）
- * 从属性值位置向后搜索 fileName/lineNumber
+ * Search for source info in chunk code (generic method)
+ * Search forward from attribute value position for fileName/lineNumber
  */
 function extractSourceNearPosition(code: string, position: number): Source | null {
-  // 从当前位置向后搜索 source 信息（在 1500 字符范围内）
+  // Search forward from current position for source info (within 1500 chars)
   const searchRange = code.slice(position, position + 1500);
   const fileMatch = searchRange.match(/fileName:\s*"([^"]+)"/);
   const lineMatch = searchRange.match(/lineNumber:\s*(\d+)/);
@@ -91,21 +91,21 @@ function extractSourceNearPosition(code: string, position: number): Source | nul
 }
 
 /**
- * 从 Turbopack chunk 代码中提取原生元素（div/span 等）的 source 信息
- * 通过 className/id 进行精确匹配
+ * Extract source info for native elements (div/span etc.) from Turbopack chunk code
+ * Match precisely via className/id
  */
 async function extractSourceFromTurbopackChunksForElement(
   tagName: string,
   className?: string,
   id?: string
 ): Promise<Source | null> {
-  // 构建缓存 key
+  // Build cache key
   const cacheKey = `${tagName}:${className || ""}:${id || ""}`;
   if (elementSignatureSourceCache.has(cacheKey)) {
     return elementSignatureSourceCache.get(cacheKey) ?? null;
   }
 
-  // 没有 className 和 id 则无法精确匹配
+  // Cannot match precisely without className or id
   if (!className && !id) {
     elementSignatureSourceCache.set(cacheKey, null);
     return null;
@@ -114,13 +114,13 @@ async function extractSourceFromTurbopackChunksForElement(
   try {
     const codes = await getAllChunkCodes();
 
-    // 收集所有可能的搜索模式
+    // Collect all possible search patterns
     const searchPatterns: string[] = [];
     if (id) {
       searchPatterns.push(id);
     }
     if (className) {
-      // 分割所有类名，每个都可以作为搜索关键词
+      // Split class names, each can be used as search keyword
       const classes = className.split(/\s+/).filter(c => c.length > 2);
       searchPatterns.push(...classes);
     }
@@ -132,18 +132,18 @@ async function extractSourceFromTurbopackChunksForElement(
 
     for (const code of codes) {
       for (const pattern of searchPatterns) {
-        // 在代码中搜索属性值
+        // Search for attribute value in code
         let searchIndex = 0;
         while (searchIndex < code.length) {
           const attrIndex = code.indexOf(`"${pattern}"`, searchIndex);
           if (attrIndex === -1) break;
 
-          // 向前搜索确认是 jsxDEV 调用（在 800 字符范围内）
+          // Search backward to confirm jsxDEV call (within 800 chars)
           const startRange = Math.max(0, attrIndex - 800);
           const beforeAttr = code.slice(startRange, attrIndex);
 
-          // 检查是否是 jsxDEV("tagName", 或类似调用
-          // 支持多种 Turbopack 格式:
+          // Check if this is jsxDEV("tagName", or similar call
+          // Supports multiple Turbopack formats:
           // - ["jsxDEV"])("div",
           // - jsxDEV("div",
           // - (0, _jsxDevRuntime.jsxDEV)("div",
@@ -179,13 +179,13 @@ async function extractSourceFromTurbopackChunksForElement(
 }
 
 /**
- * 从 Turbopack chunk 代码中提取 jsxDEV 调用的 source 信息
- * 适用于 React 19 + Turbopack 环境，Fiber 上没有 _debugSource 的情况
+ * Extract jsxDEV source info from Turbopack chunk code
+ * For React 19 + Turbopack where Fiber has no _debugSource
  */
 async function extractSourceFromTurbopackChunks(
   componentName: string
 ): Promise<Source | null> {
-  // 检查缓存
+  // Check cache
   if (componentNameSourceCache.has(componentName)) {
     return componentNameSourceCache.get(componentName) ?? null;
   }
@@ -194,7 +194,7 @@ async function extractSourceFromTurbopackChunks(
     const codes = await getAllChunkCodes();
 
     for (const code of codes) {
-      // 搜索多种组件调用模式:
+      // Search for various component call patterns:
       // - (ComponentName,
       // - jsxDEV(ComponentName,
       // - ["jsxDEV"])(ComponentName,
@@ -221,7 +221,7 @@ async function extractSourceFromTurbopackChunks(
       }
     }
 
-    // 未找到，缓存 null
+    // Not found, cache null
     componentNameSourceCache.set(componentName, null);
     return null;
   } catch {
@@ -230,8 +230,8 @@ async function extractSourceFromTurbopackChunks(
 }
 
 /**
- * 清除 Turbopack chunk 缓存
- * 用于开发时 HMR 更新后刷新缓存
+ * Clear Turbopack chunk cache
+ * Useful after HMR updates during development
  */
 export function clearTurbopackCache(): void {
   chunkCodeCache.clear();
@@ -240,7 +240,7 @@ export function clearTurbopackCache(): void {
 }
 
 /**
- * 获取第一个 rendererInterface（默认取第一个，处理多 react-dom 实例情况）
+ * Get the first rendererInterface (handles multiple react-dom instances)
  */
 function getFirstRendererInterface(): { rendererID: number; rendererInterface: RendererInterface } | null {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -259,15 +259,15 @@ function getFirstRendererInterface(): { rendererID: number; rendererInterface: R
 }
 
 /**
- * 解析 inspectElement 返回的 source 信息
- * React DevTools 返回格式可能是：
- * - 数组: [componentName, fileName, lineNumber, columnNumber]
- * - 对象: { fileName, lineNumber, columnNumber }
+ * Parse source info returned by inspectElement
+ * React DevTools may return:
+ * - Array: [componentName, fileName, lineNumber, columnNumber]
+ * - Object: { fileName, lineNumber, columnNumber }
  */
 function parseInspectElementSource(source: unknown): { fileName: string; lineNumber: number; columnNumber: number } | null {
   if (!source) return null;
 
-  // 数组格式: [componentName, fileName, lineNumber, columnNumber]
+  // Array format: [componentName, fileName, lineNumber, columnNumber]
   if (Array.isArray(source) && source.length >= 3) {
     const [, fileName, lineNumber, columnNumber] = source;
     if (typeof fileName === 'string' && typeof lineNumber === 'number') {
@@ -279,7 +279,7 @@ function parseInspectElementSource(source: unknown): { fileName: string; lineNum
     }
   }
 
-  // 对象格式: { fileName, lineNumber, columnNumber }
+  // Object format: { fileName, lineNumber, columnNumber }
   if (typeof source === 'object' && source !== null) {
     const src = source as Record<string, unknown>;
     if (typeof src.fileName === 'string' && typeof src.lineNumber === 'number') {
@@ -295,10 +295,10 @@ function parseInspectElementSource(source: unknown): { fileName: string; lineNum
 }
 
 /**
- * 通过 React DevTools 7.0.1+ rendererInterfaces API 获取 DOM 节点的源码位置
- * 这是最直接的方式，优先使用
+ * Get source location of DOM node via React DevTools 7.0.1+ rendererInterfaces API
+ * Most direct method, preferred
  *
- * 返回的是编译后位置，需要后续通过 source-map 反查原始位置
+ * Returns compiled position, needs source-map reverse lookup
  */
 export function getSourceViaRendererInterface(domElement: HTMLElement): Source | null {
   const renderer = getFirstRendererInterface();
@@ -309,18 +309,18 @@ export function getSourceViaRendererInterface(domElement: HTMLElement): Source |
   const { rendererID, rendererInterface } = renderer;
 
   try {
-    // 1. 从 DOM 获取 React 内部元素 ID
+    // 1. Get React internal element ID from DOM
     const elementID = rendererInterface.getElementIDForHostInstance(domElement as any);
     if (!elementID) {
       return null;
     }
 
-    // 2. 使用 inspectElement 获取详细信息（包含 source）
+    // 2. Use inspectElement for detailed info (including source)
     const inspectedElement = rendererInterface.inspectElement(
       rendererID,   // requestID
       elementID,    // id
       null,         // path
-      true          // forceFullData - 强制获取完整数据
+      true          // forceFullData - force full data retrieval
     );
 
     if (inspectedElement?.value?.source) {
@@ -330,11 +330,11 @@ export function getSourceViaRendererInterface(domElement: HTMLElement): Source |
       }
     }
 
-    // 3. 备用方案：通过 getElementSourceFunctionById 获取组件函数
+    // 3. Fallback: get component function via getElementSourceFunctionById
     if (rendererInterface.getElementSourceFunctionById) {
       const sourceFunc = rendererInterface.getElementSourceFunctionById(elementID);
       if (sourceFunc) {
-        // 检查函数上的 __source 属性
+        // Check __source property on function
         const funcAny = sourceFunc as any;
         if (funcAny.__source) {
           return {
@@ -353,7 +353,7 @@ export function getSourceViaRendererInterface(domElement: HTMLElement): Source |
       }
     }
   } catch (e) {
-    // 静默失败，回退到其他方法
+    // Fail silently, fall back to other methods
     if (process.env.NODE_ENV === 'development') {
       console.debug('[LocatorJS] getSourceViaRendererInterface error:', e);
     }
@@ -363,8 +363,8 @@ export function getSourceViaRendererInterface(domElement: HTMLElement): Source |
 }
 
 /**
- * 通过 Fiber 和 rendererInterfaces API 获取源码位置
- * 适用于已有 Fiber 但需要获取源码的场景
+ * Get source location via Fiber and rendererInterfaces API
+ * For cases where we have a Fiber but need its source
  */
 export function getSourceViaRendererInterfaceByFiber(fiber: Fiber): Source | null {
   const renderer = getFirstRendererInterface();
@@ -375,13 +375,13 @@ export function getSourceViaRendererInterfaceByFiber(fiber: Fiber): Source | nul
   const { rendererID, rendererInterface } = renderer;
 
   try {
-    // 尝试从 fiber.stateNode 获取 DOM 元素
+    // Try to get DOM element from fiber.stateNode
     const stateNode = fiber.stateNode;
     if (stateNode instanceof HTMLElement) {
       return getSourceViaRendererInterface(stateNode);
     }
 
-    // 对于函数组件，stateNode 为 null，尝试从子节点获取
+    // For function components, stateNode is null, try child nodes
     let childFiber = fiber.child;
     while (childFiber) {
       if (childFiber.stateNode instanceof HTMLElement) {
@@ -413,8 +413,8 @@ export function getSourceViaRendererInterfaceByFiber(fiber: Fiber): Source | nul
 }
 
 /**
- * 从函数的 toString() 中提取 sourceURL 注释
- * 某些打包工具会在函数末尾添加 //# sourceURL=xxx
+ * Extract sourceURL comment from function toString()
+ * Some bundlers append //# sourceURL=xxx at the end of functions
  */
 function extractSourceURL(funcStr: string): string | null {
   const match = funcStr.match(/\/\/[#@]\s*sourceURL=(.+?)(?:\s|$)/);
@@ -422,7 +422,7 @@ function extractSourceURL(funcStr: string): string | null {
 }
 
 /**
- * 从 React 19+ 的 _debugInfo 中提取 stack 信息
+ * Extract stack info from React 19+ _debugInfo
  */
 function extractSourceFromDebugInfo(fiber: Fiber): Source | null {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -433,10 +433,10 @@ function extractSourceFromDebugInfo(fiber: Fiber): Source | null {
   }
 
   for (const info of fiberAny._debugInfo) {
-    // React Server Components 的 stack 信息
+    // React Server Components stack info
     if (info.stack && typeof info.stack === "string") {
-      // 解析 stack 获取第一个有效的位置
-      // 格式: "at ComponentName (file:line:column)"
+      // Parse stack to get first valid position
+      // Format: "at ComponentName (file:line:column)"
       const match = info.stack.match(
         /at\s+\S+\s+\(([^:]+):(\d+):(\d+)\)/
       );
@@ -448,7 +448,7 @@ function extractSourceFromDebugInfo(fiber: Fiber): Source | null {
         };
       }
 
-      // 另一种格式: "ComponentName@file:line:column"
+      // Alternative format: "ComponentName@file:line:column"
       const firefoxMatch = info.stack.match(
         /\S+@([^:]+):(\d+):(\d+)/
       );
@@ -461,7 +461,7 @@ function extractSourceFromDebugInfo(fiber: Fiber): Source | null {
       }
     }
 
-    // 某些情况下 _debugInfo 包含 owner 信息
+    // In some cases _debugInfo contains owner info
     if (info.owner && typeof info.owner === "object") {
       const ownerSource = extractSourceFromDebugInfo(info.owner);
       if (ownerSource) {
@@ -474,8 +474,8 @@ function extractSourceFromDebugInfo(fiber: Fiber): Source | null {
 }
 
 /**
- * 从组件函数的元数据中获取 source
- * 某些构建工具会在函数上附加 __source 或类似属性
+ * Get source from component function metadata
+ * Some build tools attach __source or similar properties to functions
  */
 function extractSourceFromFunctionMeta(
   type: unknown
@@ -487,7 +487,7 @@ function extractSourceFromFunctionMeta(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const typeAny = type as any;
 
-  // 检查各种可能的 source 属性
+  // Check various possible source properties
   const sourceKeys = [
     "__source",
     "_source",
@@ -513,7 +513,7 @@ function extractSourceFromFunctionMeta(
 }
 
 /**
- * 尝试从 React DevTools hook 获取 source 信息
+ * Try to get source info from React DevTools hook
  */
 function getSourceFromDevTools(fiber: Fiber): Source | null {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -523,11 +523,11 @@ function getSourceFromDevTools(fiber: Fiber): Source | null {
   }
 
   try {
-    // React DevTools 可能提供 inspectElement API
+    // React DevTools may provide inspectElement API
     const renderers = hook.renderers;
     if (renderers) {
       for (const renderer of renderers.values()) {
-        // 某些版本的 React DevTools 提供获取 source 的方法
+        // Some React DevTools versions provide source retrieval methods
         if (renderer.getSourceForFiber) {
           const source = renderer.getSourceForFiber(fiber);
           if (source) {
@@ -537,36 +537,36 @@ function getSourceFromDevTools(fiber: Fiber): Source | null {
       }
     }
   } catch {
-    // 忽略错误
+    // Ignore errors
   }
 
   return null;
 }
 
 /**
- * 解析 Fiber 的 _debugStack（如果存在）
- * React 19 开发模式下可能包含组件栈
+ * Parse Fiber's _debugStack (if present)
+ * React 19 dev mode may include component stack
  */
 function parseDebugStack(fiber: Fiber): Source | null {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const fiberAny = fiber as any;
 
-  // React 19 可能使用 _debugStack
+  // React 19 may use _debugStack
   const stack = fiberAny._debugStack || fiberAny.__debugStack;
   if (!stack) {
     return null;
   }
 
-  // 尝试解析 stack 字符串
+  // Try to parse stack string
   if (typeof stack === "string") {
     const lines = stack.split("\n");
     for (const line of lines) {
-      // 跳过 React 内部的 frames
+      // Skip React internal frames
       if (line.includes("react-dom") || line.includes("react.")) {
         continue;
       }
 
-      // Chrome 格式
+      // Chrome format
       const chromeMatch = line.match(
         /at\s+\S+\s+\((.+?):(\d+):(\d+)\)/
       );
@@ -578,7 +578,7 @@ function parseDebugStack(fiber: Fiber): Source | null {
         };
       }
 
-      // Firefox 格式
+      // Firefox format
       const firefoxMatch = line.match(
         /\S+@(.+?):(\d+):(\d+)/
       );
@@ -596,8 +596,8 @@ function parseDebugStack(fiber: Fiber): Source | null {
 }
 
 /**
- * 主函数：从 Fiber 获取组件的原始源码位置
- * 支持异步 source-map 解析
+ * Main function: get component's original source location from Fiber
+ * Supports async source-map resolution
  */
 export async function resolveSourceFromFiber(
   fiber: Fiber
@@ -606,7 +606,7 @@ export async function resolveSourceFromFiber(
   const fiberAny = fiber as any;
   const debug = isDebugEnabled();
 
-  // 1. 检查缓存（仅当 type 是对象时使用 WeakMap）
+  // 1. Check cache (use WeakMap only when type is an object)
   if (fiberAny.type && typeof fiberAny.type === 'object' && componentSourceCache.has(fiberAny.type)) {
     const cached = componentSourceCache.get(fiberAny.type) ?? null;
     if (debug && cached) {
@@ -615,12 +615,12 @@ export async function resolveSourceFromFiber(
     return cached;
   }
 
-  // 2. [优先] 通过 React DevTools 7.0.1+ rendererInterfaces API 获取
-  // 这是最直接可靠的方式，但返回的是编译后位置，需要 source-map 反查
+  // 2. [Preferred] Get via React DevTools 7.0.1+ rendererInterfaces API
+  // Most direct and reliable, but returns compiled position, needs source-map reverse lookup
   try {
     const rendererInterfaceSource = getSourceViaRendererInterfaceByFiber(fiber);
     if (rendererInterfaceSource && rendererInterfaceSource.fileName) {
-      // 尝试通过 source-map 反查原始位置
+      // Try source-map reverse lookup for original position
       const resolved = await resolveOriginalPosition(
         rendererInterfaceSource.fileName,
         rendererInterfaceSource.lineNumber,
@@ -641,11 +641,11 @@ export async function resolveSourceFromFiber(
     if (debug) logError(SourceMethod.RENDERER_INTERFACE, e);
   }
 
-  // 3. 从 _debugInfo 获取（React 19 Server Components）
+  // 3. Get from _debugInfo (React 19 Server Components)
   try {
     const debugInfoSource = extractSourceFromDebugInfo(fiber);
     if (debugInfoSource && debugInfoSource.fileName) {
-      // 尝试通过 source-map 反查原始位置
+      // Try source-map reverse lookup for original position
       const resolved = await resolveOriginalPosition(
         debugInfoSource.fileName,
         debugInfoSource.lineNumber,
@@ -664,7 +664,7 @@ export async function resolveSourceFromFiber(
     if (debug) logError(SourceMethod.DEBUG_INFO, e);
   }
 
-  // 4. 从 _debugStack 解析
+  // 4. Parse from _debugStack
   try {
     const debugStackSource = parseDebugStack(fiber);
     if (debugStackSource && debugStackSource.fileName) {
@@ -686,7 +686,7 @@ export async function resolveSourceFromFiber(
     if (debug) logError(SourceMethod.DEBUG_STACK, e);
   }
 
-  // 5. 从组件函数元数据获取
+  // 5. Get from component function metadata
   try {
     const metaSource = extractSourceFromFunctionMeta(fiberAny.type);
     if (metaSource && metaSource.fileName) {
@@ -708,7 +708,7 @@ export async function resolveSourceFromFiber(
     if (debug) logError(SourceMethod.FUNCTION_META, e);
   }
 
-  // 6. 从 React DevTools renderers 获取（旧版 API）
+  // 6. Get from React DevTools renderers (legacy API)
   try {
     const devToolsSource = getSourceFromDevTools(fiber);
     if (devToolsSource && devToolsSource.fileName) {
@@ -730,16 +730,16 @@ export async function resolveSourceFromFiber(
     if (debug) logError(SourceMethod.DEVTOOLS_RENDERERS, e);
   }
 
-  // 7. 尝试从函数的 toString 中提取 sourceURL
+  // 7. Try to extract sourceURL from function toString()
   if (typeof fiberAny.type === "function") {
     try {
       const funcStr = fiberAny.type.toString();
       const sourceURL = extractSourceURL(funcStr);
       if (sourceURL) {
-        // sourceURL 通常是完整路径，但可能需要解析
+        // sourceURL is usually a full path but may need parsing
         const resolved: Source = {
           fileName: sourceURL,
-          lineNumber: 1, // 无法确定具体行号
+          lineNumber: 1, // Cannot determine exact line number
           columnNumber: 0,
         };
         componentSourceCache.set(fiberAny.type, resolved);
@@ -754,13 +754,13 @@ export async function resolveSourceFromFiber(
     }
   }
 
-  // 8. [Turbopack 方案] 从 chunk 代码中提取 jsxDEV 调用的 source 信息
-  // 适用于 React 19 + Next.js 15 + Turbopack 环境
+  // 8. [Turbopack] Extract jsxDEV source info from chunk code
+  // For React 19 + Next.js 15 + Turbopack environments
   const isNativeElement = typeof fiberAny.type === "string";
   const componentName = typeof fiberAny.type === "function" ? fiberAny.type.name : null;
 
   if (isNativeElement) {
-    // 原生元素（div/span 等）：尝试用标签名 + 属性精确匹配
+    // Native elements (div/span etc.): try precise match by tag + attributes
     const tagName = fiberAny.type as string;
     const props = fiberAny.memoizedProps || {};
     try {
@@ -783,7 +783,7 @@ export async function resolveSourceFromFiber(
     try {
       const turbopackSource = await extractSourceFromTurbopackChunks(componentName);
       if (turbopackSource) {
-        // Turbopack 方案获取的是组件使用位置（已经是原始路径，无需 source-map 转换）
+        // Turbopack returns component usage location (already original path, no source-map needed)
         if (fiberAny.type && typeof fiberAny.type === "object") {
           componentSourceCache.set(fiberAny.type, turbopackSource);
         }
@@ -798,7 +798,7 @@ export async function resolveSourceFromFiber(
     }
   }
 
-  // 9. 缓存 null 结果，避免重复查找（仅当 type 是对象时）
+  // 9. Cache null result to avoid repeated lookups (only when type is an object)
   if (fiberAny.type && typeof fiberAny.type === 'object') {
     componentSourceCache.set(fiberAny.type, null);
   }
@@ -807,7 +807,7 @@ export async function resolveSourceFromFiber(
 }
 
 /**
- * 同步版本：仅从缓存获取（用于非异步上下文）
+ * Synchronous: get from cache only (for non-async contexts)
  */
 export function getSourceFromCache(fiber: Fiber): Source | null {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -821,9 +821,9 @@ export function getSourceFromCache(fiber: Fiber): Source | null {
 }
 
 /**
- * 清除组件 source 缓存
+ * Clear component source cache
  */
 export function clearComponentSourceCache(): void {
-  // WeakMap 无法清除，创建新的
-  // 实际上 WeakMap 会自动回收不再引用的键
+  // WeakMap cannot be cleared, would need to create a new one
+  // In practice, WeakMap automatically garbage-collects unreferenced keys
 }

--- a/packages/runtime/src/adapters/react/clickSourceResolver.ts
+++ b/packages/runtime/src/adapters/react/clickSourceResolver.ts
@@ -1,0 +1,829 @@
+import { Source, Fiber, RendererInterface } from "@locator/shared";
+import { resolveOriginalPosition } from "./sourceMapResolver";
+import {
+  SourceMethod,
+  logSourceFound,
+  logSourceComplete,
+  logError,
+  isDebugEnabled,
+} from "./debug";
+
+/**
+ * 基于点击位置的 Source 解析器
+ * 用于 Next.js 15+ / React 19+ 使用新打包工具的环境
+ *
+ * 核心思路：
+ * 1. 优先使用 React DevTools 7.0.1+ rendererInterfaces API
+ * 2. 从 Fiber 获取组件 type（函数）
+ * 3. 解析函数的 toString() 或相关元数据获取编译后位置
+ * 4. 通过 source-map 反查原始位置
+ * 5. 从 Turbopack chunk 代码中提取 jsxDEV 调用的 source 信息
+ */
+
+/**
+ * 扩展的 DevTools Hook 类型（兼容 7.0.1+）
+ */
+type DevToolsHookWithInterfaces = {
+  rendererInterfaces?: Map<number, RendererInterface>;
+  renderers?: Map<number, unknown>;
+};
+
+// 缓存组件 type 到 source 的映射
+const componentSourceCache = new WeakMap<object, Source | null>();
+
+// 缓存 chunk 代码，避免重复请求
+const chunkCodeCache = new Map<string, string>();
+
+// 缓存组件名到 source 的映射（用于 Turbopack 方案）
+const componentNameSourceCache = new Map<string, Source | null>();
+
+// 缓存元素签名到 source 的映射（用于原生元素）
+const elementSignatureSourceCache = new Map<string, Source | null>();
+
+/**
+ * 获取所有 chunk 代码（带缓存）
+ */
+async function getAllChunkCodes(): Promise<string[]> {
+  const scripts = Array.from(
+    document.querySelectorAll('script[src*="/_next/static/chunks"]')
+  ) as HTMLScriptElement[];
+
+  const codes: string[] = [];
+  for (const script of scripts) {
+    const src = script.src;
+    if (!src) continue;
+
+    let code = chunkCodeCache.get(src);
+    if (!code) {
+      try {
+        const res = await fetch(src);
+        if (!res.ok) continue;
+        code = await res.text();
+        chunkCodeCache.set(src, code);
+      } catch {
+        continue;
+      }
+    }
+    codes.push(code);
+  }
+  return codes;
+}
+
+/**
+ * 在 chunk 代码中搜索 source 信息（通用方法）
+ * 从属性值位置向后搜索 fileName/lineNumber
+ */
+function extractSourceNearPosition(code: string, position: number): Source | null {
+  // 从当前位置向后搜索 source 信息（在 1500 字符范围内）
+  const searchRange = code.slice(position, position + 1500);
+  const fileMatch = searchRange.match(/fileName:\s*"([^"]+)"/);
+  const lineMatch = searchRange.match(/lineNumber:\s*(\d+)/);
+  const colMatch = searchRange.match(/columnNumber:\s*(\d+)/);
+
+  if (fileMatch?.[1] && lineMatch?.[1]) {
+    return {
+      fileName: fileMatch[1],
+      lineNumber: parseInt(lineMatch[1], 10),
+      columnNumber: colMatch?.[1] ? parseInt(colMatch[1], 10) : 0,
+    };
+  }
+  return null;
+}
+
+/**
+ * 从 Turbopack chunk 代码中提取原生元素（div/span 等）的 source 信息
+ * 通过 className/id 进行精确匹配
+ */
+async function extractSourceFromTurbopackChunksForElement(
+  tagName: string,
+  className?: string,
+  id?: string
+): Promise<Source | null> {
+  // 构建缓存 key
+  const cacheKey = `${tagName}:${className || ""}:${id || ""}`;
+  if (elementSignatureSourceCache.has(cacheKey)) {
+    return elementSignatureSourceCache.get(cacheKey) ?? null;
+  }
+
+  // 没有 className 和 id 则无法精确匹配
+  if (!className && !id) {
+    elementSignatureSourceCache.set(cacheKey, null);
+    return null;
+  }
+
+  try {
+    const codes = await getAllChunkCodes();
+
+    // 收集所有可能的搜索模式
+    const searchPatterns: string[] = [];
+    if (id) {
+      searchPatterns.push(id);
+    }
+    if (className) {
+      // 分割所有类名，每个都可以作为搜索关键词
+      const classes = className.split(/\s+/).filter(c => c.length > 2);
+      searchPatterns.push(...classes);
+    }
+
+    if (searchPatterns.length === 0) {
+      elementSignatureSourceCache.set(cacheKey, null);
+      return null;
+    }
+
+    for (const code of codes) {
+      for (const pattern of searchPatterns) {
+        // 在代码中搜索属性值
+        let searchIndex = 0;
+        while (searchIndex < code.length) {
+          const attrIndex = code.indexOf(`"${pattern}"`, searchIndex);
+          if (attrIndex === -1) break;
+
+          // 向前搜索确认是 jsxDEV 调用（在 800 字符范围内）
+          const startRange = Math.max(0, attrIndex - 800);
+          const beforeAttr = code.slice(startRange, attrIndex);
+
+          // 检查是否是 jsxDEV("tagName", 或类似调用
+          // 支持多种 Turbopack 格式:
+          // - ["jsxDEV"])("div",
+          // - jsxDEV("div",
+          // - (0, _jsxDevRuntime.jsxDEV)("div",
+          // - _jsx("div",
+          const jsxPatterns = [
+            new RegExp(`\\["jsxDEV"\\]\\)\\("${tagName}",[^}]*$`),
+            new RegExp(`jsxDEV\\("${tagName}",[^}]*$`),
+            new RegExp(`\\.jsxDEV\\)\\("${tagName}",[^}]*$`),
+            new RegExp(`_jsx\\("${tagName}",[^}]*$`),
+            new RegExp(`jsx\\("${tagName}",[^}]*$`),
+          ];
+
+          const hasJsxCall = jsxPatterns.some(p => p.test(beforeAttr));
+
+          if (hasJsxCall) {
+            const source = extractSourceNearPosition(code, attrIndex);
+            if (source) {
+              elementSignatureSourceCache.set(cacheKey, source);
+              return source;
+            }
+          }
+
+          searchIndex = attrIndex + 1;
+        }
+      }
+    }
+
+    elementSignatureSourceCache.set(cacheKey, null);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 从 Turbopack chunk 代码中提取 jsxDEV 调用的 source 信息
+ * 适用于 React 19 + Turbopack 环境，Fiber 上没有 _debugSource 的情况
+ */
+async function extractSourceFromTurbopackChunks(
+  componentName: string
+): Promise<Source | null> {
+  // 检查缓存
+  if (componentNameSourceCache.has(componentName)) {
+    return componentNameSourceCache.get(componentName) ?? null;
+  }
+
+  try {
+    const codes = await getAllChunkCodes();
+
+    for (const code of codes) {
+      // 搜索多种组件调用模式:
+      // - (ComponentName,
+      // - jsxDEV(ComponentName,
+      // - ["jsxDEV"])(ComponentName,
+      const searchPatterns = [
+        `(${componentName},`,
+        `jsxDEV(${componentName},`,
+        `jsx(${componentName},`,
+      ];
+
+      for (const pattern of searchPatterns) {
+        let searchIndex = 0;
+        while (searchIndex < code.length) {
+          const callIndex = code.indexOf(pattern, searchIndex);
+          if (callIndex === -1) break;
+
+          const source = extractSourceNearPosition(code, callIndex);
+          if (source) {
+            componentNameSourceCache.set(componentName, source);
+            return source;
+          }
+
+          searchIndex = callIndex + 1;
+        }
+      }
+    }
+
+    // 未找到，缓存 null
+    componentNameSourceCache.set(componentName, null);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 清除 Turbopack chunk 缓存
+ * 用于开发时 HMR 更新后刷新缓存
+ */
+export function clearTurbopackCache(): void {
+  chunkCodeCache.clear();
+  componentNameSourceCache.clear();
+  elementSignatureSourceCache.clear();
+}
+
+/**
+ * 获取第一个 rendererInterface（默认取第一个，处理多 react-dom 实例情况）
+ */
+function getFirstRendererInterface(): { rendererID: number; rendererInterface: RendererInterface } | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const hook = (window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__ as DevToolsHookWithInterfaces | undefined;
+  if (!hook?.rendererInterfaces || hook.rendererInterfaces.size === 0) {
+    return null;
+  }
+
+  const entries = Array.from(hook.rendererInterfaces.entries());
+  const firstEntry = entries[0];
+  if (!firstEntry) {
+    return null;
+  }
+  const [rendererID, rendererInterface] = firstEntry;
+  return { rendererID, rendererInterface };
+}
+
+/**
+ * 解析 inspectElement 返回的 source 信息
+ * React DevTools 返回格式可能是：
+ * - 数组: [componentName, fileName, lineNumber, columnNumber]
+ * - 对象: { fileName, lineNumber, columnNumber }
+ */
+function parseInspectElementSource(source: unknown): { fileName: string; lineNumber: number; columnNumber: number } | null {
+  if (!source) return null;
+
+  // 数组格式: [componentName, fileName, lineNumber, columnNumber]
+  if (Array.isArray(source) && source.length >= 3) {
+    const [, fileName, lineNumber, columnNumber] = source;
+    if (typeof fileName === 'string' && typeof lineNumber === 'number') {
+      return {
+        fileName,
+        lineNumber,
+        columnNumber: typeof columnNumber === 'number' ? columnNumber : 0,
+      };
+    }
+  }
+
+  // 对象格式: { fileName, lineNumber, columnNumber }
+  if (typeof source === 'object' && source !== null) {
+    const src = source as Record<string, unknown>;
+    if (typeof src.fileName === 'string' && typeof src.lineNumber === 'number') {
+      return {
+        fileName: src.fileName,
+        lineNumber: src.lineNumber,
+        columnNumber: typeof src.columnNumber === 'number' ? src.columnNumber : 0,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 通过 React DevTools 7.0.1+ rendererInterfaces API 获取 DOM 节点的源码位置
+ * 这是最直接的方式，优先使用
+ *
+ * 返回的是编译后位置，需要后续通过 source-map 反查原始位置
+ */
+export function getSourceViaRendererInterface(domElement: HTMLElement): Source | null {
+  const renderer = getFirstRendererInterface();
+  if (!renderer) {
+    return null;
+  }
+
+  const { rendererID, rendererInterface } = renderer;
+
+  try {
+    // 1. 从 DOM 获取 React 内部元素 ID
+    const elementID = rendererInterface.getElementIDForHostInstance(domElement as any);
+    if (!elementID) {
+      return null;
+    }
+
+    // 2. 使用 inspectElement 获取详细信息（包含 source）
+    const inspectedElement = rendererInterface.inspectElement(
+      rendererID,   // requestID
+      elementID,    // id
+      null,         // path
+      true          // forceFullData - 强制获取完整数据
+    );
+
+    if (inspectedElement?.value?.source) {
+      const parsed = parseInspectElementSource(inspectedElement.value.source);
+      if (parsed) {
+        return parsed;
+      }
+    }
+
+    // 3. 备用方案：通过 getElementSourceFunctionById 获取组件函数
+    if (rendererInterface.getElementSourceFunctionById) {
+      const sourceFunc = rendererInterface.getElementSourceFunctionById(elementID);
+      if (sourceFunc) {
+        // 检查函数上的 __source 属性
+        const funcAny = sourceFunc as any;
+        if (funcAny.__source) {
+          return {
+            fileName: funcAny.__source.fileName,
+            lineNumber: funcAny.__source.lineNumber,
+            columnNumber: funcAny.__source.columnNumber ?? 0,
+          };
+        }
+        if (funcAny._source) {
+          return {
+            fileName: funcAny._source.fileName,
+            lineNumber: funcAny._source.lineNumber,
+            columnNumber: funcAny._source.columnNumber ?? 0,
+          };
+        }
+      }
+    }
+  } catch (e) {
+    // 静默失败，回退到其他方法
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('[LocatorJS] getSourceViaRendererInterface error:', e);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 通过 Fiber 和 rendererInterfaces API 获取源码位置
+ * 适用于已有 Fiber 但需要获取源码的场景
+ */
+export function getSourceViaRendererInterfaceByFiber(fiber: Fiber): Source | null {
+  const renderer = getFirstRendererInterface();
+  if (!renderer) {
+    return null;
+  }
+
+  const { rendererID, rendererInterface } = renderer;
+
+  try {
+    // 尝试从 fiber.stateNode 获取 DOM 元素
+    const stateNode = fiber.stateNode;
+    if (stateNode instanceof HTMLElement) {
+      return getSourceViaRendererInterface(stateNode);
+    }
+
+    // 对于函数组件，stateNode 为 null，尝试从子节点获取
+    let childFiber = fiber.child;
+    while (childFiber) {
+      if (childFiber.stateNode instanceof HTMLElement) {
+        const elementID = rendererInterface.getElementIDForHostInstance(childFiber.stateNode as any);
+        if (elementID) {
+          const inspectedElement = rendererInterface.inspectElement(
+            rendererID,
+            elementID,
+            null,
+            true
+          );
+          if (inspectedElement?.value?.source) {
+            const parsed = parseInspectElementSource(inspectedElement.value.source);
+            if (parsed) {
+              return parsed;
+            }
+          }
+        }
+      }
+      childFiber = childFiber.sibling;
+    }
+  } catch (e) {
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('[LocatorJS] getSourceViaRendererInterfaceByFiber error:', e);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 从函数的 toString() 中提取 sourceURL 注释
+ * 某些打包工具会在函数末尾添加 //# sourceURL=xxx
+ */
+function extractSourceURL(funcStr: string): string | null {
+  const match = funcStr.match(/\/\/[#@]\s*sourceURL=(.+?)(?:\s|$)/);
+  return match && match[1] ? match[1] : null;
+}
+
+/**
+ * 从 React 19+ 的 _debugInfo 中提取 stack 信息
+ */
+function extractSourceFromDebugInfo(fiber: Fiber): Source | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fiberAny = fiber as any;
+
+  if (!fiberAny._debugInfo || !Array.isArray(fiberAny._debugInfo)) {
+    return null;
+  }
+
+  for (const info of fiberAny._debugInfo) {
+    // React Server Components 的 stack 信息
+    if (info.stack && typeof info.stack === "string") {
+      // 解析 stack 获取第一个有效的位置
+      // 格式: "at ComponentName (file:line:column)"
+      const match = info.stack.match(
+        /at\s+\S+\s+\(([^:]+):(\d+):(\d+)\)/
+      );
+      if (match) {
+        return {
+          fileName: match[1],
+          lineNumber: parseInt(match[2], 10),
+          columnNumber: parseInt(match[3], 10),
+        };
+      }
+
+      // 另一种格式: "ComponentName@file:line:column"
+      const firefoxMatch = info.stack.match(
+        /\S+@([^:]+):(\d+):(\d+)/
+      );
+      if (firefoxMatch) {
+        return {
+          fileName: firefoxMatch[1],
+          lineNumber: parseInt(firefoxMatch[2], 10),
+          columnNumber: parseInt(firefoxMatch[3], 10),
+        };
+      }
+    }
+
+    // 某些情况下 _debugInfo 包含 owner 信息
+    if (info.owner && typeof info.owner === "object") {
+      const ownerSource = extractSourceFromDebugInfo(info.owner);
+      if (ownerSource) {
+        return ownerSource;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 从组件函数的元数据中获取 source
+ * 某些构建工具会在函数上附加 __source 或类似属性
+ */
+function extractSourceFromFunctionMeta(
+  type: unknown
+): Source | null {
+  if (typeof type !== "function" && typeof type !== "object") {
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const typeAny = type as any;
+
+  // 检查各种可能的 source 属性
+  const sourceKeys = [
+    "__source",
+    "_source",
+    "__componentSource",
+    "$$source",
+    "__debugSource",
+  ];
+
+  for (const key of sourceKeys) {
+    if (typeAny[key]) {
+      const src = typeAny[key];
+      if (src.fileName && src.lineNumber) {
+        return {
+          fileName: src.fileName,
+          lineNumber: src.lineNumber,
+          columnNumber: src.columnNumber,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 尝试从 React DevTools hook 获取 source 信息
+ */
+function getSourceFromDevTools(fiber: Fiber): Source | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const hook = (window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) {
+    return null;
+  }
+
+  try {
+    // React DevTools 可能提供 inspectElement API
+    const renderers = hook.renderers;
+    if (renderers) {
+      for (const renderer of renderers.values()) {
+        // 某些版本的 React DevTools 提供获取 source 的方法
+        if (renderer.getSourceForFiber) {
+          const source = renderer.getSourceForFiber(fiber);
+          if (source) {
+            return source;
+          }
+        }
+      }
+    }
+  } catch {
+    // 忽略错误
+  }
+
+  return null;
+}
+
+/**
+ * 解析 Fiber 的 _debugStack（如果存在）
+ * React 19 开发模式下可能包含组件栈
+ */
+function parseDebugStack(fiber: Fiber): Source | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fiberAny = fiber as any;
+
+  // React 19 可能使用 _debugStack
+  const stack = fiberAny._debugStack || fiberAny.__debugStack;
+  if (!stack) {
+    return null;
+  }
+
+  // 尝试解析 stack 字符串
+  if (typeof stack === "string") {
+    const lines = stack.split("\n");
+    for (const line of lines) {
+      // 跳过 React 内部的 frames
+      if (line.includes("react-dom") || line.includes("react.")) {
+        continue;
+      }
+
+      // Chrome 格式
+      const chromeMatch = line.match(
+        /at\s+\S+\s+\((.+?):(\d+):(\d+)\)/
+      );
+      if (chromeMatch && chromeMatch[1] && chromeMatch[2] && chromeMatch[3]) {
+        return {
+          fileName: chromeMatch[1],
+          lineNumber: parseInt(chromeMatch[2], 10),
+          columnNumber: parseInt(chromeMatch[3], 10),
+        };
+      }
+
+      // Firefox 格式
+      const firefoxMatch = line.match(
+        /\S+@(.+?):(\d+):(\d+)/
+      );
+      if (firefoxMatch && firefoxMatch[1] && firefoxMatch[2] && firefoxMatch[3]) {
+        return {
+          fileName: firefoxMatch[1],
+          lineNumber: parseInt(firefoxMatch[2], 10),
+          columnNumber: parseInt(firefoxMatch[3], 10),
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * 主函数：从 Fiber 获取组件的原始源码位置
+ * 支持异步 source-map 解析
+ */
+export async function resolveSourceFromFiber(
+  fiber: Fiber
+): Promise<Source | null> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fiberAny = fiber as any;
+  const debug = isDebugEnabled();
+
+  // 1. 检查缓存（仅当 type 是对象时使用 WeakMap）
+  if (fiberAny.type && typeof fiberAny.type === 'object' && componentSourceCache.has(fiberAny.type)) {
+    const cached = componentSourceCache.get(fiberAny.type) ?? null;
+    if (debug && cached) {
+      logSourceFound(SourceMethod.CACHE_HIT, fiber, cached, true);
+    }
+    return cached;
+  }
+
+  // 2. [优先] 通过 React DevTools 7.0.1+ rendererInterfaces API 获取
+  // 这是最直接可靠的方式，但返回的是编译后位置，需要 source-map 反查
+  try {
+    const rendererInterfaceSource = getSourceViaRendererInterfaceByFiber(fiber);
+    if (rendererInterfaceSource && rendererInterfaceSource.fileName) {
+      // 尝试通过 source-map 反查原始位置
+      const resolved = await resolveOriginalPosition(
+        rendererInterfaceSource.fileName,
+        rendererInterfaceSource.lineNumber,
+        rendererInterfaceSource.columnNumber ?? 0
+      );
+
+      const finalSource = resolved || rendererInterfaceSource;
+      if (fiberAny.type && typeof fiberAny.type === 'object') {
+        componentSourceCache.set(fiberAny.type, finalSource);
+      }
+      if (debug) {
+        logSourceFound(SourceMethod.RENDERER_INTERFACE, fiber, finalSource, true);
+        logSourceComplete(true, SourceMethod.RENDERER_INTERFACE, finalSource);
+      }
+      return finalSource;
+    }
+  } catch (e) {
+    if (debug) logError(SourceMethod.RENDERER_INTERFACE, e);
+  }
+
+  // 3. 从 _debugInfo 获取（React 19 Server Components）
+  try {
+    const debugInfoSource = extractSourceFromDebugInfo(fiber);
+    if (debugInfoSource && debugInfoSource.fileName) {
+      // 尝试通过 source-map 反查原始位置
+      const resolved = await resolveOriginalPosition(
+        debugInfoSource.fileName,
+        debugInfoSource.lineNumber,
+        debugInfoSource.columnNumber ?? 0
+      );
+      if (resolved && fiberAny.type && typeof fiberAny.type === 'object') {
+        componentSourceCache.set(fiberAny.type, resolved);
+      }
+      if (debug && resolved) {
+        logSourceFound(SourceMethod.DEBUG_INFO, fiber, resolved, true);
+        logSourceComplete(true, SourceMethod.DEBUG_INFO, resolved);
+      }
+      return resolved;
+    }
+  } catch (e) {
+    if (debug) logError(SourceMethod.DEBUG_INFO, e);
+  }
+
+  // 4. 从 _debugStack 解析
+  try {
+    const debugStackSource = parseDebugStack(fiber);
+    if (debugStackSource && debugStackSource.fileName) {
+      const resolved = await resolveOriginalPosition(
+        debugStackSource.fileName,
+        debugStackSource.lineNumber,
+        debugStackSource.columnNumber ?? 0
+      );
+      if (resolved && fiberAny.type && typeof fiberAny.type === 'object') {
+        componentSourceCache.set(fiberAny.type, resolved);
+      }
+      if (debug && resolved) {
+        logSourceFound(SourceMethod.DEBUG_STACK, fiber, resolved, true);
+        logSourceComplete(true, SourceMethod.DEBUG_STACK, resolved);
+      }
+      return resolved;
+    }
+  } catch (e) {
+    if (debug) logError(SourceMethod.DEBUG_STACK, e);
+  }
+
+  // 5. 从组件函数元数据获取
+  try {
+    const metaSource = extractSourceFromFunctionMeta(fiberAny.type);
+    if (metaSource && metaSource.fileName) {
+      const resolved = await resolveOriginalPosition(
+        metaSource.fileName,
+        metaSource.lineNumber,
+        metaSource.columnNumber ?? 0
+      );
+      if (resolved && fiberAny.type && typeof fiberAny.type === 'object') {
+        componentSourceCache.set(fiberAny.type, resolved);
+      }
+      if (debug && resolved) {
+        logSourceFound(SourceMethod.FUNCTION_META, fiber, resolved, true);
+        logSourceComplete(true, SourceMethod.FUNCTION_META, resolved);
+      }
+      return resolved;
+    }
+  } catch (e) {
+    if (debug) logError(SourceMethod.FUNCTION_META, e);
+  }
+
+  // 6. 从 React DevTools renderers 获取（旧版 API）
+  try {
+    const devToolsSource = getSourceFromDevTools(fiber);
+    if (devToolsSource && devToolsSource.fileName) {
+      const resolved = await resolveOriginalPosition(
+        devToolsSource.fileName,
+        devToolsSource.lineNumber,
+        devToolsSource.columnNumber ?? 0
+      );
+      if (resolved && fiberAny.type && typeof fiberAny.type === 'object') {
+        componentSourceCache.set(fiberAny.type, resolved);
+      }
+      if (debug && resolved) {
+        logSourceFound(SourceMethod.DEVTOOLS_RENDERERS, fiber, resolved, true);
+        logSourceComplete(true, SourceMethod.DEVTOOLS_RENDERERS, resolved);
+      }
+      return resolved;
+    }
+  } catch (e) {
+    if (debug) logError(SourceMethod.DEVTOOLS_RENDERERS, e);
+  }
+
+  // 7. 尝试从函数的 toString 中提取 sourceURL
+  if (typeof fiberAny.type === "function") {
+    try {
+      const funcStr = fiberAny.type.toString();
+      const sourceURL = extractSourceURL(funcStr);
+      if (sourceURL) {
+        // sourceURL 通常是完整路径，但可能需要解析
+        const resolved: Source = {
+          fileName: sourceURL,
+          lineNumber: 1, // 无法确定具体行号
+          columnNumber: 0,
+        };
+        componentSourceCache.set(fiberAny.type, resolved);
+        if (debug) {
+          logSourceFound(SourceMethod.SOURCE_URL, fiber, resolved, true);
+          logSourceComplete(true, SourceMethod.SOURCE_URL, resolved);
+        }
+        return resolved;
+      }
+    } catch (e) {
+      if (debug) logError(SourceMethod.SOURCE_URL, e);
+    }
+  }
+
+  // 8. [Turbopack 方案] 从 chunk 代码中提取 jsxDEV 调用的 source 信息
+  // 适用于 React 19 + Next.js 15 + Turbopack 环境
+  const isNativeElement = typeof fiberAny.type === "string";
+  const componentName = typeof fiberAny.type === "function" ? fiberAny.type.name : null;
+
+  if (isNativeElement) {
+    // 原生元素（div/span 等）：尝试用标签名 + 属性精确匹配
+    const tagName = fiberAny.type as string;
+    const props = fiberAny.memoizedProps || {};
+    try {
+      const turbopackSource = await extractSourceFromTurbopackChunksForElement(
+        tagName,
+        props.className,
+        props.id
+      );
+      if (turbopackSource) {
+        if (debug) {
+          logSourceFound(SourceMethod.TURBOPACK_ELEMENT, fiber, turbopackSource, true);
+          logSourceComplete(true, SourceMethod.TURBOPACK_ELEMENT, turbopackSource);
+        }
+        return turbopackSource;
+      }
+    } catch (e) {
+      if (debug) logError(SourceMethod.TURBOPACK_ELEMENT, e);
+    }
+  } else if (componentName && componentName !== "Anonymous") {
+    try {
+      const turbopackSource = await extractSourceFromTurbopackChunks(componentName);
+      if (turbopackSource) {
+        // Turbopack 方案获取的是组件使用位置（已经是原始路径，无需 source-map 转换）
+        if (fiberAny.type && typeof fiberAny.type === "object") {
+          componentSourceCache.set(fiberAny.type, turbopackSource);
+        }
+        if (debug) {
+          logSourceFound(SourceMethod.TURBOPACK_COMPONENT, fiber, turbopackSource, true);
+          logSourceComplete(true, SourceMethod.TURBOPACK_COMPONENT, turbopackSource);
+        }
+        return turbopackSource;
+      }
+    } catch (e) {
+      if (debug) logError(SourceMethod.TURBOPACK_COMPONENT, e);
+    }
+  }
+
+  // 9. 缓存 null 结果，避免重复查找（仅当 type 是对象时）
+  if (fiberAny.type && typeof fiberAny.type === 'object') {
+    componentSourceCache.set(fiberAny.type, null);
+  }
+
+  return null;
+}
+
+/**
+ * 同步版本：仅从缓存获取（用于非异步上下文）
+ */
+export function getSourceFromCache(fiber: Fiber): Source | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fiberAny = fiber as any;
+
+  if (fiberAny.type && typeof fiberAny.type === 'object' && componentSourceCache.has(fiberAny.type)) {
+    return componentSourceCache.get(fiberAny.type) ?? null;
+  }
+
+  return null;
+}
+
+/**
+ * 清除组件 source 缓存
+ */
+export function clearComponentSourceCache(): void {
+  // WeakMap 无法清除，创建新的
+  // 实际上 WeakMap 会自动回收不再引用的键
+}

--- a/packages/runtime/src/adapters/react/clickSourceResolver.ts
+++ b/packages/runtime/src/adapters/react/clickSourceResolver.ts
@@ -1,5 +1,5 @@
 import { Source, Fiber, RendererInterface } from "@locator/shared";
-import { resolveOriginalPosition } from "./sourceMapResolver";
+import { resolveOriginalPosition, fileUrlToPath } from "./sourceMapResolver";
 import {
   SourceMethod,
   logSourceFound,
@@ -7,6 +7,99 @@ import {
   logError,
   isDebugEnabled,
 } from "./debug";
+
+/**
+ * Clean up stack frame file paths
+ * Handles React Server Component URLs: about://React/Server/file:///path -> /path
+ * Handles Turbopack chunk query params: /path.js?5 -> /path.js
+ */
+function cleanStackFileName(fileName: string): string {
+  let cleaned = fileName;
+
+  // Strip about://React/Server/ prefix (React 19 Server Components)
+  if (cleaned.startsWith("about://React/Server/")) {
+    cleaned = cleaned.slice("about://React/Server/".length);
+  }
+
+  // Convert file:// URLs to local paths
+  cleaned = fileUrlToPath(cleaned);
+
+  // Strip query params from chunk paths (e.g. .js?5 -> .js)
+  const queryIdx = cleaned.indexOf("?");
+  if (queryIdx !== -1) {
+    cleaned = cleaned.slice(0, queryIdx);
+  }
+
+  return cleaned;
+}
+
+/**
+ * Check if a fileName looks like a compiled chunk (not an original source file)
+ */
+function isChunkUrl(fileName: string): boolean {
+  return (
+    fileName.startsWith("http://") ||
+    fileName.startsWith("https://") ||
+    fileName.includes("/_next/") ||
+    fileName.includes(".next/dev/server/chunks/")
+  );
+}
+
+// Cached Turbopack project root (undefined = not yet resolved)
+let turbopackProjectRoot: string | null | undefined = undefined;
+
+// Cached Next.js app root for resolving relative paths from /__nextjs_original-stack-frames
+let nextjsAppRoot: string | null | undefined = undefined;
+
+/**
+ * Resolve Turbopack [project]/ prefix to absolute path
+ * Infers the project root by matching source map sources against the relative path
+ */
+async function resolveProjectPrefix(fileName: string): Promise<string> {
+  if (!fileName.startsWith("[project]/")) return fileName;
+
+  const relativePath = fileName.slice("[project]/".length);
+
+  if (turbopackProjectRoot !== undefined) {
+    return turbopackProjectRoot
+      ? turbopackProjectRoot + "/" + relativePath
+      : fileName;
+  }
+
+  // Infer project root from source map sources
+  const scripts = Array.from(
+    document.querySelectorAll('script[src*="/_next/static/chunks"]')
+  ) as HTMLScriptElement[];
+
+  for (const script of scripts) {
+    try {
+      const res = await fetch(script.src + ".map");
+      if (!res.ok) continue;
+      const map = await res.json();
+
+      const sources: string[] = map.sections
+        ? map.sections.flatMap((s: { map?: { sources?: string[] } }) => s.map?.sources || [])
+        : map.sources || [];
+
+      for (const source of sources) {
+        if (!source.startsWith("file:///")) continue;
+        const absPath = fileUrlToPath(source);
+        if (absPath.endsWith(relativePath)) {
+          turbopackProjectRoot = absPath.slice(
+            0,
+            absPath.length - relativePath.length - 1
+          );
+          return turbopackProjectRoot + "/" + relativePath;
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  turbopackProjectRoot = null;
+  return fileName;
+}
 
 /**
  * Click-based source resolver
@@ -422,6 +515,25 @@ function extractSourceURL(funcStr: string): string | null {
 }
 
 /**
+ * Extract source info from JSX-embedded fileName/lineNumber in function body
+ * Turbopack's JSX transform embeds source info as arguments to jsxDEV calls
+ * inside the function body (visible via toString()).
+ */
+function extractSourceFromFunctionBody(funcStr: string): Source | null {
+  const fileMatch = funcStr.match(/fileName:\s*"([^"]+)"/);
+  const lineMatch = funcStr.match(/lineNumber:\s*(\d+)/);
+  if (fileMatch?.[1] && lineMatch?.[1]) {
+    const colMatch = funcStr.match(/columnNumber:\s*(\d+)/);
+    return {
+      fileName: fileMatch[1],
+      lineNumber: parseInt(lineMatch[1], 10),
+      columnNumber: colMatch?.[1] ? parseInt(colMatch[1], 10) : 0,
+    };
+  }
+  return null;
+}
+
+/**
  * Extract stack info from React 19+ _debugInfo
  */
 function extractSourceFromDebugInfo(fiber: Fiber): Source | null {
@@ -543,56 +655,194 @@ function getSourceFromDevTools(fiber: Fiber): Source | null {
   return null;
 }
 
+interface DebugStackResult {
+  source: Source;
+  /** Raw file URL from the stack frame (before cleaning), needed for Next.js API */
+  rawFileUrl: string;
+  /** Method/component name from the stack frame */
+  methodName: string;
+}
+
 /**
  * Parse Fiber's _debugStack (if present)
  * React 19 dev mode may include component stack
  */
-function parseDebugStack(fiber: Fiber): Source | null {
+function parseDebugStack(fiber: Fiber): DebugStackResult | null {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const fiberAny = fiber as any;
 
   // React 19 may use _debugStack
-  const stack = fiberAny._debugStack || fiberAny.__debugStack;
-  if (!stack) {
+  const rawStack = fiberAny._debugStack || fiberAny.__debugStack;
+  if (!rawStack) {
     return null;
   }
 
-  // Try to parse stack string
-  if (typeof stack === "string") {
-    const lines = stack.split("\n");
-    for (const line of lines) {
-      // Skip React internal frames
-      if (line.includes("react-dom") || line.includes("react.")) {
-        continue;
-      }
+  // React 19 stores _debugStack as an Error object — extract .stack string
+  let stackStr: string | null = null;
+  if (typeof rawStack === "string") {
+    stackStr = rawStack;
+  } else if (rawStack instanceof Error || (typeof rawStack === "object" && typeof rawStack.stack === "string")) {
+    stackStr = rawStack.stack;
+  }
 
-      // Chrome format
-      const chromeMatch = line.match(
-        /at\s+\S+\s+\((.+?):(\d+):(\d+)\)/
-      );
-      if (chromeMatch && chromeMatch[1] && chromeMatch[2] && chromeMatch[3]) {
-        return {
-          fileName: chromeMatch[1],
-          lineNumber: parseInt(chromeMatch[2], 10),
-          columnNumber: parseInt(chromeMatch[3], 10),
-        };
-      }
+  if (!stackStr) {
+    return null;
+  }
 
-      // Firefox format
-      const firefoxMatch = line.match(
-        /\S+@(.+?):(\d+):(\d+)/
-      );
-      if (firefoxMatch && firefoxMatch[1] && firefoxMatch[2] && firefoxMatch[3]) {
-        return {
-          fileName: firefoxMatch[1],
-          lineNumber: parseInt(firefoxMatch[2], 10),
-          columnNumber: parseInt(firefoxMatch[3], 10),
-        };
-      }
+  const lines = stackStr.split("\n");
+  for (const line of lines) {
+    // Skip React internal and JSX runtime frames
+    if (
+      line.includes("react-dom") ||
+      line.includes("react.") ||
+      line.includes("react-server-dom") ||
+      line.includes("react_stack_bottom_frame") ||
+      line.includes("react-stack-top-frame") ||
+      line.includes("jsxDEV") ||
+      line.includes("fakeJSXCallSite")
+    ) {
+      continue;
+    }
+
+    // Chrome format: "at ComponentName (url:line:col)"
+    const chromeMatch = line.match(
+      /at\s+(\S+)\s+\((.+?):(\d+):(\d+)\)/
+    );
+    if (chromeMatch && chromeMatch[2] && chromeMatch[3] && chromeMatch[4]) {
+      const cleaned = cleanStackFileName(chromeMatch[2]);
+      return {
+        source: {
+          fileName: cleaned,
+          lineNumber: parseInt(chromeMatch[3], 10),
+          columnNumber: parseInt(chromeMatch[4], 10),
+        },
+        rawFileUrl: chromeMatch[2],
+        methodName: chromeMatch[1] ?? "<unknown>",
+      };
+    }
+
+    // Firefox format: "functionName@url:line:col"
+    const firefoxMatch = line.match(
+      /(\S+)@(.+?):(\d+):(\d+)/
+    );
+    if (firefoxMatch && firefoxMatch[2] && firefoxMatch[3] && firefoxMatch[4]) {
+      const cleaned = cleanStackFileName(firefoxMatch[2]);
+      return {
+        source: {
+          fileName: cleaned,
+          lineNumber: parseInt(firefoxMatch[3], 10),
+          columnNumber: parseInt(firefoxMatch[4], 10),
+        },
+        rawFileUrl: firefoxMatch[2],
+        methodName: firefoxMatch[1] ?? "<unknown>",
+      };
     }
   }
 
   return null;
+}
+
+/**
+ * Resolve a relative path from Next.js API to an absolute path
+ * Uses /__nextjs_source-map to get the SSR chunk's source map and find file:// absolute paths
+ */
+async function resolveNextjsRelativePath(
+  relativePath: string,
+  rawChunkUrl: string,
+): Promise<string> {
+  // Use cached result if available
+  if (nextjsAppRoot !== undefined) {
+    return nextjsAppRoot ? nextjsAppRoot + "/" + relativePath : relativePath;
+  }
+
+  // Fetch source map for the SSR chunk via Next.js dev server
+  try {
+    const mapRes = await fetch(
+      `/__nextjs_source-map?filename=${encodeURIComponent(rawChunkUrl)}`
+    );
+    if (mapRes.ok) {
+      const map = await mapRes.json();
+      const sources: string[] = map.sections
+        ? map.sections.flatMap(
+            (s: { map?: { sources?: string[] } }) => s.map?.sources || []
+          )
+        : map.sources || [];
+
+      for (const src of sources) {
+        if (!src.startsWith("file:///")) continue;
+        const absPath = fileUrlToPath(src);
+        if (absPath.endsWith("/" + relativePath)) {
+          nextjsAppRoot = absPath.slice(
+            0,
+            absPath.length - relativePath.length - 1
+          );
+          return absPath;
+        }
+      }
+    }
+  } catch {
+    // Fall through
+  }
+
+  nextjsAppRoot = null;
+  return relativePath;
+}
+
+/**
+ * Resolve source via Next.js dev server's stack frame API
+ * Uses /__nextjs_original-stack-frames (internal API used by error overlay)
+ * Only works in Next.js dev mode
+ */
+async function resolveViaNextDevServer(
+  rawFileUrl: string,
+  line: number,
+  column: number,
+  methodName: string,
+): Promise<Source | null> {
+  try {
+    const res = await fetch("/__nextjs_original-stack-frames", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        frames: [{
+          file: rawFileUrl,
+          methodName,
+          line1: line,
+          column1: column,
+        }],
+        isServer: true,
+        isAppDirectory: true,
+      }),
+    });
+
+    if (!res.ok) return null;
+
+    const result = await res.json();
+    if (!Array.isArray(result) || result.length === 0) return null;
+
+    const entry = result[0];
+    if (entry.status !== "fulfilled" || !entry.value?.originalStackFrame) {
+      return null;
+    }
+
+    const sf = entry.value.originalStackFrame;
+    if (!sf.file || sf.ignored) return null;
+
+    // The API returns relative paths (e.g. "app/page.tsx")
+    // Resolve to absolute via SSR chunk source map
+    let fileName = sf.file;
+    if (!fileName.startsWith("/")) {
+      fileName = await resolveNextjsRelativePath(fileName, rawFileUrl);
+    }
+
+    return {
+      fileName,
+      lineNumber: sf.line1 ?? 1,
+      columnNumber: sf.column1 ?? 0,
+    };
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -666,21 +916,58 @@ export async function resolveSourceFromFiber(
 
   // 4. Parse from _debugStack
   try {
-    const debugStackSource = parseDebugStack(fiber);
-    if (debugStackSource && debugStackSource.fileName) {
-      const resolved = await resolveOriginalPosition(
-        debugStackSource.fileName,
-        debugStackSource.lineNumber,
-        debugStackSource.columnNumber ?? 0
-      );
-      if (resolved && fiberAny.type && typeof fiberAny.type === 'object') {
-        componentSourceCache.set(fiberAny.type, resolved);
+    const debugStackResult = parseDebugStack(fiber);
+    if (debugStackResult && debugStackResult.source.fileName) {
+      const { source: debugStackSource, rawFileUrl, methodName } = debugStackResult;
+      // For chunk/compiled URLs, try source-map resolution
+      if (isChunkUrl(debugStackSource.fileName)) {
+        const resolved = await resolveOriginalPosition(
+          debugStackSource.fileName,
+          debugStackSource.lineNumber,
+          debugStackSource.columnNumber ?? 0
+        );
+        // Only use the result if it resolved to an original source file
+        if (resolved && !isChunkUrl(resolved.fileName)) {
+          if (fiberAny.type && typeof fiberAny.type === 'object') {
+            componentSourceCache.set(fiberAny.type, resolved);
+          }
+          if (debug) {
+            logSourceFound(SourceMethod.DEBUG_STACK, fiber, resolved, true);
+            logSourceComplete(true, SourceMethod.DEBUG_STACK, resolved);
+          }
+          return resolved;
+        }
+
+        // Client-side source-map failed (e.g. SSR chunk maps not served via HTTP)
+        // Try Next.js dev server API which can resolve server-side source maps
+        const nextResolved = await resolveViaNextDevServer(
+          rawFileUrl,
+          debugStackSource.lineNumber,
+          debugStackSource.columnNumber ?? 0,
+          methodName,
+        );
+        if (nextResolved && !isChunkUrl(nextResolved.fileName)) {
+          if (fiberAny.type && typeof fiberAny.type === 'object') {
+            componentSourceCache.set(fiberAny.type, nextResolved);
+          }
+          if (debug) {
+            logSourceFound(SourceMethod.DEBUG_STACK, fiber, nextResolved, true);
+            logSourceComplete(true, SourceMethod.DEBUG_STACK, nextResolved);
+          }
+          return nextResolved;
+        }
+        // Both failed — skip, let parent fiber try
+      } else {
+        // Already a local file path — use directly
+        if (fiberAny.type && typeof fiberAny.type === 'object') {
+          componentSourceCache.set(fiberAny.type, debugStackSource);
+        }
+        if (debug) {
+          logSourceFound(SourceMethod.DEBUG_STACK, fiber, debugStackSource, true);
+          logSourceComplete(true, SourceMethod.DEBUG_STACK, debugStackSource);
+        }
+        return debugStackSource;
       }
-      if (debug && resolved) {
-        logSourceFound(SourceMethod.DEBUG_STACK, fiber, resolved, true);
-        logSourceComplete(true, SourceMethod.DEBUG_STACK, resolved);
-      }
-      return resolved;
     }
   } catch (e) {
     if (debug) logError(SourceMethod.DEBUG_STACK, e);
@@ -749,6 +1036,20 @@ export async function resolveSourceFromFiber(
         }
         return resolved;
       }
+
+      // 7b. Extract source from JSX-embedded fileName/lineNumber in function body
+      // Turbopack embeds source info as jsxDEV arguments visible via toString()
+      const bodySource = extractSourceFromFunctionBody(funcStr);
+      if (bodySource && bodySource.fileName) {
+        // Resolve [project]/ prefix to absolute path
+        bodySource.fileName = await resolveProjectPrefix(bodySource.fileName);
+        componentSourceCache.set(fiberAny.type, bodySource);
+        if (debug) {
+          logSourceFound(SourceMethod.FUNCTION_BODY_JSX, fiber, bodySource, true);
+          logSourceComplete(true, SourceMethod.FUNCTION_BODY_JSX, bodySource);
+        }
+        return bodySource;
+      }
     } catch (e) {
       if (debug) logError(SourceMethod.SOURCE_URL, e);
     }
@@ -770,6 +1071,7 @@ export async function resolveSourceFromFiber(
         props.id
       );
       if (turbopackSource) {
+        turbopackSource.fileName = await resolveProjectPrefix(turbopackSource.fileName);
         if (debug) {
           logSourceFound(SourceMethod.TURBOPACK_ELEMENT, fiber, turbopackSource, true);
           logSourceComplete(true, SourceMethod.TURBOPACK_ELEMENT, turbopackSource);
@@ -783,6 +1085,7 @@ export async function resolveSourceFromFiber(
     try {
       const turbopackSource = await extractSourceFromTurbopackChunks(componentName);
       if (turbopackSource) {
+        turbopackSource.fileName = await resolveProjectPrefix(turbopackSource.fileName);
         // Turbopack returns component usage location (already original path, no source-map needed)
         if (fiberAny.type && typeof fiberAny.type === "object") {
           componentSourceCache.set(fiberAny.type, turbopackSource);

--- a/packages/runtime/src/adapters/react/debug.test.ts
+++ b/packages/runtime/src/adapters/react/debug.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, expect, test, beforeEach, vi } from "vitest";
+import {
+  isDebugEnabled,
+  enableLocatorDebug,
+  disableLocatorDebug,
+  setDebugMode,
+  logSourceFound,
+  SourceMethod,
+} from "./debug";
+
+describe("debug mode toggle", () => {
+  beforeEach(() => {
+    disableLocatorDebug();
+    // Reset window flag
+    (window as any).__LOCATORJS_DEBUG__ = false;
+  });
+
+  test("disabled by default after reset", () => {
+    expect(isDebugEnabled()).toBe(false);
+  });
+
+  test("enableLocatorDebug enables debug mode", () => {
+    enableLocatorDebug();
+    expect(isDebugEnabled()).toBe(true);
+  });
+
+  test("disableLocatorDebug disables debug mode", () => {
+    enableLocatorDebug();
+    disableLocatorDebug();
+    expect(isDebugEnabled()).toBe(false);
+  });
+
+  test("setDebugMode sets mode silently", () => {
+    setDebugMode(true);
+    expect(isDebugEnabled()).toBe(true);
+    setDebugMode(false);
+    expect(isDebugEnabled()).toBe(false);
+  });
+
+  test("window.__LOCATORJS_DEBUG__ flag syncs with enable/disable", () => {
+    enableLocatorDebug();
+    expect((window as any).__LOCATORJS_DEBUG__).toBe(true);
+    disableLocatorDebug();
+    expect((window as any).__LOCATORJS_DEBUG__).toBe(false);
+  });
+
+  test("respects window global when set externally", () => {
+    (window as any).__LOCATORJS_DEBUG__ = true;
+    expect(isDebugEnabled()).toBe(true);
+  });
+});
+
+describe("logSourceFound", () => {
+  beforeEach(() => {
+    disableLocatorDebug();
+    (window as any).__LOCATORJS_DEBUG__ = false;
+    (window as any).__LOCATORJS_DEBUG_HISTORY__ = [];
+  });
+
+  test("does not log when debug disabled", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    logSourceFound(
+      SourceMethod.FIBER_DEBUG_SOURCE,
+      { type: "div", tag: 5 },
+      { fileName: "test.tsx", lineNumber: 10 }
+    );
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  test("logs when debug enabled", () => {
+    enableLocatorDebug();
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    logSourceFound(
+      SourceMethod.FIBER_DEBUG_SOURCE,
+      { type: "div", tag: 5 },
+      { fileName: "test.tsx", lineNumber: 10 }
+    );
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  test("adds entry to debug history", () => {
+    enableLocatorDebug();
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    logSourceFound(
+      SourceMethod.FIBER_DEBUG_SOURCE,
+      { type: "div", tag: 5 },
+      { fileName: "test.tsx", lineNumber: 10 }
+    );
+    const history = (window as any).__LOCATORJS_DEBUG_HISTORY__;
+    expect(history.length).toBeGreaterThan(0);
+    const last = history[history.length - 1];
+    expect(last.method).toBe(SourceMethod.FIBER_DEBUG_SOURCE);
+    expect(last.source.fileName).toBe("test.tsx");
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("SourceMethod enum", () => {
+  test("has expected sync methods", () => {
+    expect(SourceMethod.FIBER_DEBUG_SOURCE).toBe("fiber._debugSource");
+    expect(SourceMethod.CACHE_HIT).toBe("cache (previously async-resolved)");
+  });
+
+  test("has expected async methods", () => {
+    expect(SourceMethod.RENDERER_INTERFACE).toContain("rendererInterfaces");
+    expect(SourceMethod.TURBOPACK_ELEMENT).toContain("Turbopack");
+  });
+});

--- a/packages/runtime/src/adapters/react/debug.ts
+++ b/packages/runtime/src/adapters/react/debug.ts
@@ -27,6 +27,7 @@ export const SourceMethod = {
   FUNCTION_META: "function metadata (__source/_source)",
   DEVTOOLS_RENDERERS: "React DevTools renderers (legacy API)",
   SOURCE_URL: "function toString() sourceURL",
+  FUNCTION_BODY_JSX: "function toString() JSX source info",
   TURBOPACK_ELEMENT: "Turbopack chunk (native element)",
   TURBOPACK_COMPONENT: "Turbopack chunk (component name)",
 } as const;
@@ -246,6 +247,19 @@ export function logError(method: SourceMethodType, error: unknown): void {
     "color: #FF9800",
     error
   );
+}
+
+/**
+ * Register the diagnose function.
+ * Called from outside to avoid circular imports (debug.ts must not import resolution modules).
+ */
+export function registerDiagnose(
+  diagnoseFn: () => Promise<void>
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof window !== "undefined") {
+    (window as any).locatorDiagnose = diagnoseFn;
+  }
 }
 
 // Expose helpers on window at init

--- a/packages/runtime/src/adapters/react/debug.ts
+++ b/packages/runtime/src/adapters/react/debug.ts
@@ -1,0 +1,258 @@
+/**
+ * LocatorJS Debug 模块
+ * 用于调试源码定位流程，帮助排查跳转问题
+ *
+ * 启用方式：
+ * 1. 浏览器控制台执行: window.__LOCATORJS_DEBUG__ = true
+ * 2. 或在代码中调用: enableLocatorDebug()
+ */
+
+// 定位方式枚举
+export const SourceMethod = {
+  // 同步方式 (findDebugSource.ts)
+  FIBER_DEBUG_SOURCE: "fiber._debugSource",
+  ELEMENT_TYPE_SOURCE: "fiber.elementType._source",
+  TYPE_SOURCE: "fiber.type._source",
+  FIBER_DEBUG_SOURCE_ALT: "fiber.__debugSource",
+  MEMOIZED_PROPS_SOURCE: "fiber.memoizedProps.__source",
+  PENDING_PROPS_SOURCE: "fiber.pendingProps.__source",
+  DEBUG_INFO_STACK: "fiber._debugInfo[].stack",
+  TYPE_COMPONENT_SOURCE: "fiber.type.__componentSource",
+  CACHE_HIT: "cache (之前异步解析的结果)",
+
+  // 异步方式 (clickSourceResolver.ts)
+  RENDERER_INTERFACE: "rendererInterfaces API (React DevTools 7.0.1+)",
+  DEBUG_INFO: "_debugInfo (React 19 Server Components)",
+  DEBUG_STACK: "_debugStack (React 19)",
+  FUNCTION_META: "函数元数据 (__source/_source)",
+  DEVTOOLS_RENDERERS: "React DevTools renderers (旧版 API)",
+  SOURCE_URL: "函数 toString() sourceURL",
+  TURBOPACK_ELEMENT: "Turbopack chunk (原生元素)",
+  TURBOPACK_COMPONENT: "Turbopack chunk (组件名)",
+} as const;
+
+export type SourceMethodType = (typeof SourceMethod)[keyof typeof SourceMethod];
+
+interface DebugInfo {
+  method: SourceMethodType;
+  fiberType: string;
+  fiberTag: number;
+  source: {
+    fileName: string;
+    lineNumber: number;
+    columnNumber?: number;
+  } | null;
+  async: boolean;
+  timestamp: number;
+}
+
+// 全局 debug 状态
+let debugEnabled = false;
+const debugHistory: DebugInfo[] = [];
+const MAX_HISTORY = 50;
+
+/**
+ * 检查是否启用 debug 模式
+ */
+export function isDebugEnabled(): boolean {
+  // 支持通过 window 全局变量控制
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof window !== "undefined" && (window as any).__LOCATORJS_DEBUG__) {
+    return true;
+  }
+  return debugEnabled;
+}
+
+/**
+ * 启用 debug 模式
+ */
+export function enableLocatorDebug(): void {
+  debugEnabled = true;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof window !== "undefined") {
+    (window as any).__LOCATORJS_DEBUG__ = true;
+  }
+  console.log(
+    "%c[LocatorJS Debug] 已启用调试模式",
+    "color: #4CAF50; font-weight: bold"
+  );
+  console.log("查看历史记录: window.__LOCATORJS_DEBUG_HISTORY__");
+  console.log("禁用: window.__LOCATORJS_DEBUG__ = false 或 disableLocatorDebug()");
+}
+
+/**
+ * 禁用 debug 模式
+ */
+export function disableLocatorDebug(): void {
+  debugEnabled = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof window !== "undefined") {
+    (window as any).__LOCATORJS_DEBUG__ = false;
+  }
+  console.log(
+    "%c[LocatorJS Debug] 已禁用调试模式",
+    "color: #f44336; font-weight: bold"
+  );
+}
+
+/**
+ * 设置 debug 模式（供设置面板调用，静默模式）
+ */
+export function setDebugMode(enabled: boolean): void {
+  debugEnabled = enabled;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof window !== "undefined") {
+    (window as any).__LOCATORJS_DEBUG__ = enabled;
+  }
+}
+
+/**
+ * 获取 Fiber 类型描述
+ */
+function getFiberTypeDesc(fiber: unknown): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const f = fiber as any;
+  if (!f) return "null";
+
+  const type = f.type;
+  if (typeof type === "string") {
+    return `<${type}>`; // 原生元素如 <div>
+  }
+  if (typeof type === "function") {
+    return type.displayName || type.name || "Anonymous";
+  }
+  if (type && typeof type === "object") {
+    // memo/forwardRef 等
+    if (type.displayName) return type.displayName;
+    if (type.render?.displayName) return type.render.displayName;
+    if (type.render?.name) return type.render.name;
+  }
+  return "Unknown";
+}
+
+/**
+ * 记录 debug 信息
+ */
+export function logSourceFound(
+  method: SourceMethodType,
+  fiber: unknown,
+  source: { fileName: string; lineNumber: number; columnNumber?: number } | null,
+  async = false
+): void {
+  if (!isDebugEnabled()) return;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const f = fiber as any;
+  const fiberType = getFiberTypeDesc(fiber);
+  const fiberTag = f?.tag ?? -1;
+
+  const info: DebugInfo = {
+    method,
+    fiberType,
+    fiberTag,
+    source,
+    async,
+    timestamp: Date.now(),
+  };
+
+  // 添加到历史记录
+  debugHistory.push(info);
+  if (debugHistory.length > MAX_HISTORY) {
+    debugHistory.shift();
+  }
+
+  // 暴露到 window
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (typeof window !== "undefined") {
+    (window as any).__LOCATORJS_DEBUG_HISTORY__ = debugHistory;
+  }
+
+  // 控制台输出
+  const asyncLabel = async ? "[异步]" : "[同步]";
+  const methodColor = async ? "#2196F3" : "#4CAF50";
+
+  if (source) {
+    console.log(
+      `%c[LocatorJS] ${asyncLabel} 源码定位成功`,
+      `color: ${methodColor}; font-weight: bold`,
+      "\n方式:", method,
+      "\n组件:", fiberType,
+      "\n位置:", `${source.fileName}:${source.lineNumber}:${source.columnNumber ?? 0}`
+    );
+  } else {
+    console.log(
+      `%c[LocatorJS] ${asyncLabel} 尝试方式: ${method}`,
+      "color: #9E9E9E",
+      `(${fiberType}) - 未找到`
+    );
+  }
+}
+
+/**
+ * 记录定位开始
+ */
+export function logSourceStart(fiber: unknown, element?: HTMLElement): void {
+  if (!isDebugEnabled()) return;
+
+  const fiberType = getFiberTypeDesc(fiber);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fiberTag = (fiber as any)?.tag ?? -1;
+
+  console.group(
+    `%c[LocatorJS] 开始定位源码`,
+    "color: #FF9800; font-weight: bold"
+  );
+  console.log("Fiber:", fiberType, `(tag: ${fiberTag})`);
+  if (element) {
+    console.log("DOM 元素:", element);
+  }
+  console.log("Fiber 对象:", fiber);
+  console.groupEnd();
+}
+
+/**
+ * 记录定位完成
+ */
+export function logSourceComplete(
+  success: boolean,
+  method?: SourceMethodType,
+  source?: { fileName: string; lineNumber: number; columnNumber?: number } | null
+): void {
+  if (!isDebugEnabled()) return;
+
+  if (success && source) {
+    console.log(
+      `%c[LocatorJS] ✅ 定位完成`,
+      "color: #4CAF50; font-weight: bold",
+      "\n最终方式:", method,
+      "\n目标位置:", `${source.fileName}:${source.lineNumber}:${source.columnNumber ?? 0}`
+    );
+  } else {
+    console.log(
+      `%c[LocatorJS] ❌ 定位失败 - 所有方式均未找到源码`,
+      "color: #f44336; font-weight: bold"
+    );
+  }
+}
+
+/**
+ * 记录错误
+ */
+export function logError(method: SourceMethodType, error: unknown): void {
+  if (!isDebugEnabled()) return;
+
+  console.warn(
+    `%c[LocatorJS] ⚠️ ${method} 出错:`,
+    "color: #FF9800",
+    error
+  );
+}
+
+// 初始化时暴露到 window
+if (typeof window !== "undefined") {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any;
+  w.__LOCATORJS_DEBUG_HISTORY__ = debugHistory;
+  w.enableLocatorDebug = enableLocatorDebug;
+  w.disableLocatorDebug = disableLocatorDebug;
+}

--- a/packages/runtime/src/adapters/react/debug.ts
+++ b/packages/runtime/src/adapters/react/debug.ts
@@ -1,15 +1,15 @@
 /**
- * LocatorJS Debug 模块
- * 用于调试源码定位流程，帮助排查跳转问题
+ * LocatorJS Debug Module
+ * Helps debug source location resolution and troubleshoot navigation issues.
  *
- * 启用方式：
- * 1. 浏览器控制台执行: window.__LOCATORJS_DEBUG__ = true
- * 2. 或在代码中调用: enableLocatorDebug()
+ * Enable via:
+ * 1. Browser console: window.__LOCATORJS_DEBUG__ = true
+ * 2. Or call: enableLocatorDebug()
  */
 
-// 定位方式枚举
+// Source resolution method enum
 export const SourceMethod = {
-  // 同步方式 (findDebugSource.ts)
+  // Synchronous methods (findDebugSource.ts)
   FIBER_DEBUG_SOURCE: "fiber._debugSource",
   ELEMENT_TYPE_SOURCE: "fiber.elementType._source",
   TYPE_SOURCE: "fiber.type._source",
@@ -18,17 +18,17 @@ export const SourceMethod = {
   PENDING_PROPS_SOURCE: "fiber.pendingProps.__source",
   DEBUG_INFO_STACK: "fiber._debugInfo[].stack",
   TYPE_COMPONENT_SOURCE: "fiber.type.__componentSource",
-  CACHE_HIT: "cache (之前异步解析的结果)",
+  CACHE_HIT: "cache (previously async-resolved)",
 
-  // 异步方式 (clickSourceResolver.ts)
+  // Asynchronous methods (clickSourceResolver.ts)
   RENDERER_INTERFACE: "rendererInterfaces API (React DevTools 7.0.1+)",
   DEBUG_INFO: "_debugInfo (React 19 Server Components)",
   DEBUG_STACK: "_debugStack (React 19)",
-  FUNCTION_META: "函数元数据 (__source/_source)",
-  DEVTOOLS_RENDERERS: "React DevTools renderers (旧版 API)",
-  SOURCE_URL: "函数 toString() sourceURL",
-  TURBOPACK_ELEMENT: "Turbopack chunk (原生元素)",
-  TURBOPACK_COMPONENT: "Turbopack chunk (组件名)",
+  FUNCTION_META: "function metadata (__source/_source)",
+  DEVTOOLS_RENDERERS: "React DevTools renderers (legacy API)",
+  SOURCE_URL: "function toString() sourceURL",
+  TURBOPACK_ELEMENT: "Turbopack chunk (native element)",
+  TURBOPACK_COMPONENT: "Turbopack chunk (component name)",
 } as const;
 
 export type SourceMethodType = (typeof SourceMethod)[keyof typeof SourceMethod];
@@ -46,16 +46,16 @@ interface DebugInfo {
   timestamp: number;
 }
 
-// 全局 debug 状态
+// Global debug state
 let debugEnabled = false;
 const debugHistory: DebugInfo[] = [];
 const MAX_HISTORY = 50;
 
 /**
- * 检查是否启用 debug 模式
+ * Check if debug mode is enabled
  */
 export function isDebugEnabled(): boolean {
-  // 支持通过 window 全局变量控制
+  // Also check window global variable
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (typeof window !== "undefined" && (window as any).__LOCATORJS_DEBUG__) {
     return true;
@@ -64,7 +64,7 @@ export function isDebugEnabled(): boolean {
 }
 
 /**
- * 启用 debug 模式
+ * Enable debug mode
  */
 export function enableLocatorDebug(): void {
   debugEnabled = true;
@@ -73,15 +73,15 @@ export function enableLocatorDebug(): void {
     (window as any).__LOCATORJS_DEBUG__ = true;
   }
   console.log(
-    "%c[LocatorJS Debug] 已启用调试模式",
+    "%c[LocatorJS Debug] Debug mode enabled",
     "color: #4CAF50; font-weight: bold"
   );
-  console.log("查看历史记录: window.__LOCATORJS_DEBUG_HISTORY__");
-  console.log("禁用: window.__LOCATORJS_DEBUG__ = false 或 disableLocatorDebug()");
+  console.log("View debug history: window.__LOCATORJS_DEBUG_HISTORY__");
+  console.log("Disable: window.__LOCATORJS_DEBUG__ = false or disableLocatorDebug()");
 }
 
 /**
- * 禁用 debug 模式
+ * Disable debug mode
  */
 export function disableLocatorDebug(): void {
   debugEnabled = false;
@@ -90,13 +90,13 @@ export function disableLocatorDebug(): void {
     (window as any).__LOCATORJS_DEBUG__ = false;
   }
   console.log(
-    "%c[LocatorJS Debug] 已禁用调试模式",
+    "%c[LocatorJS Debug] Debug mode disabled",
     "color: #f44336; font-weight: bold"
   );
 }
 
 /**
- * 设置 debug 模式（供设置面板调用，静默模式）
+ * Set debug mode (called from settings panel, silent)
  */
 export function setDebugMode(enabled: boolean): void {
   debugEnabled = enabled;
@@ -107,7 +107,7 @@ export function setDebugMode(enabled: boolean): void {
 }
 
 /**
- * 获取 Fiber 类型描述
+ * Get a human-readable description of a Fiber's type
  */
 function getFiberTypeDesc(fiber: unknown): string {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -116,13 +116,13 @@ function getFiberTypeDesc(fiber: unknown): string {
 
   const type = f.type;
   if (typeof type === "string") {
-    return `<${type}>`; // 原生元素如 <div>
+    return `<${type}>`; // native element e.g. <div>
   }
   if (typeof type === "function") {
     return type.displayName || type.name || "Anonymous";
   }
   if (type && typeof type === "object") {
-    // memo/forwardRef 等
+    // memo/forwardRef etc.
     if (type.displayName) return type.displayName;
     if (type.render?.displayName) return type.render.displayName;
     if (type.render?.name) return type.render.name;
@@ -131,7 +131,7 @@ function getFiberTypeDesc(fiber: unknown): string {
 }
 
 /**
- * 记录 debug 信息
+ * Log debug info when a source is found
  */
 export function logSourceFound(
   method: SourceMethodType,
@@ -155,41 +155,41 @@ export function logSourceFound(
     timestamp: Date.now(),
   };
 
-  // 添加到历史记录
+  // Add to history
   debugHistory.push(info);
   if (debugHistory.length > MAX_HISTORY) {
     debugHistory.shift();
   }
 
-  // 暴露到 window
+  // Expose on window
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (typeof window !== "undefined") {
     (window as any).__LOCATORJS_DEBUG_HISTORY__ = debugHistory;
   }
 
-  // 控制台输出
-  const asyncLabel = async ? "[异步]" : "[同步]";
+  // Console output
+  const asyncLabel = async ? "[async]" : "[sync]";
   const methodColor = async ? "#2196F3" : "#4CAF50";
 
   if (source) {
     console.log(
-      `%c[LocatorJS] ${asyncLabel} 源码定位成功`,
+      `%c[LocatorJS] ${asyncLabel} Source found`,
       `color: ${methodColor}; font-weight: bold`,
-      "\n方式:", method,
-      "\n组件:", fiberType,
-      "\n位置:", `${source.fileName}:${source.lineNumber}:${source.columnNumber ?? 0}`
+      "\nMethod:", method,
+      "\nComponent:", fiberType,
+      "\nLocation:", `${source.fileName}:${source.lineNumber}:${source.columnNumber ?? 0}`
     );
   } else {
     console.log(
-      `%c[LocatorJS] ${asyncLabel} 尝试方式: ${method}`,
+      `%c[LocatorJS] ${asyncLabel} Tried: ${method}`,
       "color: #9E9E9E",
-      `(${fiberType}) - 未找到`
+      `(${fiberType}) - not found`
     );
   }
 }
 
 /**
- * 记录定位开始
+ * Log when source resolution starts
  */
 export function logSourceStart(fiber: unknown, element?: HTMLElement): void {
   if (!isDebugEnabled()) return;
@@ -199,19 +199,19 @@ export function logSourceStart(fiber: unknown, element?: HTMLElement): void {
   const fiberTag = (fiber as any)?.tag ?? -1;
 
   console.group(
-    `%c[LocatorJS] 开始定位源码`,
+    `%c[LocatorJS] Starting source resolution`,
     "color: #FF9800; font-weight: bold"
   );
   console.log("Fiber:", fiberType, `(tag: ${fiberTag})`);
   if (element) {
-    console.log("DOM 元素:", element);
+    console.log("DOM element:", element);
   }
-  console.log("Fiber 对象:", fiber);
+  console.log("Fiber object:", fiber);
   console.groupEnd();
 }
 
 /**
- * 记录定位完成
+ * Log when source resolution completes
  */
 export function logSourceComplete(
   success: boolean,
@@ -222,33 +222,33 @@ export function logSourceComplete(
 
   if (success && source) {
     console.log(
-      `%c[LocatorJS] ✅ 定位完成`,
+      `%c[LocatorJS] Location complete`,
       "color: #4CAF50; font-weight: bold",
-      "\n最终方式:", method,
-      "\n目标位置:", `${source.fileName}:${source.lineNumber}:${source.columnNumber ?? 0}`
+      "\nFinal method:", method,
+      "\nTarget location:", `${source.fileName}:${source.lineNumber}:${source.columnNumber ?? 0}`
     );
   } else {
     console.log(
-      `%c[LocatorJS] ❌ 定位失败 - 所有方式均未找到源码`,
+      `%c[LocatorJS] Location failed - no source found via any method`,
       "color: #f44336; font-weight: bold"
     );
   }
 }
 
 /**
- * 记录错误
+ * Log an error during source resolution
  */
 export function logError(method: SourceMethodType, error: unknown): void {
   if (!isDebugEnabled()) return;
 
   console.warn(
-    `%c[LocatorJS] ⚠️ ${method} 出错:`,
+    `%c[LocatorJS] ${method} error:`,
     "color: #FF9800",
     error
   );
 }
 
-// 初始化时暴露到 window
+// Expose helpers on window at init
 if (typeof window !== "undefined") {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const w = window as any;

--- a/packages/runtime/src/adapters/react/findDebugSource.ts
+++ b/packages/runtime/src/adapters/react/findDebugSource.ts
@@ -1,14 +1,158 @@
 import { Fiber, Source } from "@locator/shared";
+import { resolveSourceFromFiber, getSourceFromCache } from "./clickSourceResolver";
+import {
+  SourceMethod,
+  logSourceFound,
+  logSourceStart,
+  logSourceComplete,
+  isDebugEnabled,
+  SourceMethodType,
+} from "./debug";
 
+/**
+ * 尝试从 Fiber 中获取 source 信息（同步版本）
+ * React 19 / Next.js 15+ 可能将 source 存储在不同位置
+ * 返回 [source, method] 用于 debug
+ */
+function getSourceFromFiber(fiber: Fiber): [Source | null, SourceMethodType | null] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const fiberAny = fiber as any;
+
+  // 1. 传统方式：直接从 _debugSource 获取
+  if (fiber._debugSource) {
+    return [fiber._debugSource, SourceMethod.FIBER_DEBUG_SOURCE];
+  }
+
+  // 2. React 19+：尝试从 type 或 elementType 获取
+  // 从 elementType._source 获取
+  if (fiberAny.elementType?._source) {
+    return [fiberAny.elementType._source, SourceMethod.ELEMENT_TYPE_SOURCE];
+  }
+
+  // 从 type._source 获取
+  if (fiberAny.type?._source) {
+    return [fiberAny.type._source, SourceMethod.TYPE_SOURCE];
+  }
+
+  // 3. Next.js / Turbopack: 尝试从 __debugSource 获取
+  if (fiberAny.__debugSource) {
+    return [fiberAny.__debugSource, SourceMethod.FIBER_DEBUG_SOURCE_ALT];
+  }
+
+  // 4. 尝试从 memoizedProps 中获取 __source（JSX 转换注入）
+  if (fiberAny.memoizedProps?.__source) {
+    return [fiberAny.memoizedProps.__source, SourceMethod.MEMOIZED_PROPS_SOURCE];
+  }
+
+  // 5. 尝试从 pendingProps 中获取 __source
+  if (fiberAny.pendingProps?.__source) {
+    return [fiberAny.pendingProps.__source, SourceMethod.PENDING_PROPS_SOURCE];
+  }
+
+  // 6. 尝试从 _debugInfo 获取（React 19 Server Components）
+  if (fiberAny._debugInfo && Array.isArray(fiberAny._debugInfo)) {
+    for (const info of fiberAny._debugInfo) {
+      if (info.stack) {
+        // 解析 stack 获取第一个有效的位置
+        const match = info.stack.match(/at\s+\S+\s+\(([^:]+):(\d+):(\d+)\)/);
+        if (match) {
+          return [{
+            fileName: match[1],
+            lineNumber: parseInt(match[2], 10),
+            columnNumber: parseInt(match[3], 10),
+          }, SourceMethod.DEBUG_INFO_STACK];
+        }
+      }
+    }
+  }
+
+  // 7. 尝试从 type 的函数名推断（最后手段）
+  // 某些情况下可以获取到组件定义的文件信息
+  if (typeof fiberAny.type === "function" && fiberAny.type.__componentSource) {
+    return [fiberAny.type.__componentSource, SourceMethod.TYPE_COMPONENT_SOURCE];
+  }
+
+  return [null, null];
+}
+
+/**
+ * 同步版本：从 Fiber 查找 debug source
+ * 优先使用传统方式，适用于大多数场景
+ */
 export function findDebugSource(
   fiber: Fiber
 ): { fiber: Fiber; source: Source } | null {
+  const debug = isDebugEnabled();
+
+  if (debug) {
+    logSourceStart(fiber);
+  }
+
   let current: Fiber | null = fiber;
   while (current) {
-    if (current._debugSource) {
-      return { fiber: current, source: current._debugSource };
+    const [source, method] = getSourceFromFiber(current);
+    if (source) {
+      if (debug) {
+        logSourceFound(method!, current, source, false);
+        logSourceComplete(true, method!, source);
+      }
+      return { fiber: current, source };
+    }
+
+    // 尝试从缓存获取（如果之前异步解析过）
+    const cached = getSourceFromCache(current);
+    if (cached) {
+      if (debug) {
+        logSourceFound(SourceMethod.CACHE_HIT, current, cached, false);
+        logSourceComplete(true, SourceMethod.CACHE_HIT, cached);
+      }
+      return { fiber: current, source: cached };
+    }
+
+    current = current._debugOwner || null;
+  }
+
+  if (debug) {
+    logSourceComplete(false);
+  }
+
+  return null;
+}
+
+/**
+ * 异步版本：从 Fiber 查找 debug source
+ * 当同步方式失败时，尝试通过 source-map 解析
+ * 适用于 Next.js 15+ / React 19+ 使用新打包工具的环境
+ */
+export async function findDebugSourceAsync(
+  fiber: Fiber
+): Promise<{ fiber: Fiber; source: Source } | null> {
+  // 1. 先尝试同步方式
+  const syncResult = findDebugSource(fiber);
+  if (syncResult) {
+    return syncResult;
+  }
+
+  const debug = isDebugEnabled();
+  if (debug) {
+    console.log(
+      "%c[LocatorJS] 同步方式未找到，尝试异步解析...",
+      "color: #2196F3; font-style: italic"
+    );
+  }
+
+  // 2. 同步方式失败，尝试异步解析（通过 source-map）
+  let current: Fiber | null = fiber;
+  while (current) {
+    const source = await resolveSourceFromFiber(current);
+    if (source) {
+      return { fiber: current, source };
     }
     current = current._debugOwner || null;
+  }
+
+  if (debug) {
+    logSourceComplete(false);
   }
 
   return null;

--- a/packages/runtime/src/adapters/react/findDebugSource.ts
+++ b/packages/runtime/src/adapters/react/findDebugSource.ts
@@ -10,50 +10,50 @@ import {
 } from "./debug";
 
 /**
- * 尝试从 Fiber 中获取 source 信息（同步版本）
- * React 19 / Next.js 15+ 可能将 source 存储在不同位置
- * 返回 [source, method] 用于 debug
+ * Try to get source info from Fiber (synchronous)
+ * React 19 / Next.js 15+ may store source in different locations
+ * Returns [source, method] for debug logging
  */
 function getSourceFromFiber(fiber: Fiber): [Source | null, SourceMethodType | null] {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const fiberAny = fiber as any;
 
-  // 1. 传统方式：直接从 _debugSource 获取
+  // 1. Traditional: get directly from _debugSource
   if (fiber._debugSource) {
     return [fiber._debugSource, SourceMethod.FIBER_DEBUG_SOURCE];
   }
 
-  // 2. React 19+：尝试从 type 或 elementType 获取
-  // 从 elementType._source 获取
+  // 2. React 19+: try from type or elementType
+  // Get from elementType._source
   if (fiberAny.elementType?._source) {
     return [fiberAny.elementType._source, SourceMethod.ELEMENT_TYPE_SOURCE];
   }
 
-  // 从 type._source 获取
+  // Get from type._source
   if (fiberAny.type?._source) {
     return [fiberAny.type._source, SourceMethod.TYPE_SOURCE];
   }
 
-  // 3. Next.js / Turbopack: 尝试从 __debugSource 获取
+  // 3. Next.js / Turbopack: try from __debugSource
   if (fiberAny.__debugSource) {
     return [fiberAny.__debugSource, SourceMethod.FIBER_DEBUG_SOURCE_ALT];
   }
 
-  // 4. 尝试从 memoizedProps 中获取 __source（JSX 转换注入）
+  // 4. Try __source from memoizedProps (JSX transform injection)
   if (fiberAny.memoizedProps?.__source) {
     return [fiberAny.memoizedProps.__source, SourceMethod.MEMOIZED_PROPS_SOURCE];
   }
 
-  // 5. 尝试从 pendingProps 中获取 __source
+  // 5. Try __source from pendingProps
   if (fiberAny.pendingProps?.__source) {
     return [fiberAny.pendingProps.__source, SourceMethod.PENDING_PROPS_SOURCE];
   }
 
-  // 6. 尝试从 _debugInfo 获取（React 19 Server Components）
+  // 6. Try from _debugInfo (React 19 Server Components)
   if (fiberAny._debugInfo && Array.isArray(fiberAny._debugInfo)) {
     for (const info of fiberAny._debugInfo) {
       if (info.stack) {
-        // 解析 stack 获取第一个有效的位置
+        // Parse stack for first valid position
         const match = info.stack.match(/at\s+\S+\s+\(([^:]+):(\d+):(\d+)\)/);
         if (match) {
           return [{
@@ -66,8 +66,8 @@ function getSourceFromFiber(fiber: Fiber): [Source | null, SourceMethodType | nu
     }
   }
 
-  // 7. 尝试从 type 的函数名推断（最后手段）
-  // 某些情况下可以获取到组件定义的文件信息
+  // 7. Try inferring from type function (last resort)
+  // May get component definition file info
   if (typeof fiberAny.type === "function" && fiberAny.type.__componentSource) {
     return [fiberAny.type.__componentSource, SourceMethod.TYPE_COMPONENT_SOURCE];
   }
@@ -76,8 +76,8 @@ function getSourceFromFiber(fiber: Fiber): [Source | null, SourceMethodType | nu
 }
 
 /**
- * 同步版本：从 Fiber 查找 debug source
- * 优先使用传统方式，适用于大多数场景
+ * Synchronous: find debug source from Fiber
+ * Prefers traditional methods, suitable for most scenarios
  */
 export function findDebugSource(
   fiber: Fiber
@@ -99,7 +99,7 @@ export function findDebugSource(
       return { fiber: current, source };
     }
 
-    // 尝试从缓存获取（如果之前异步解析过）
+    // Try from cache (if previously async-resolved)
     const cached = getSourceFromCache(current);
     if (cached) {
       if (debug) {
@@ -120,14 +120,14 @@ export function findDebugSource(
 }
 
 /**
- * 异步版本：从 Fiber 查找 debug source
- * 当同步方式失败时，尝试通过 source-map 解析
- * 适用于 Next.js 15+ / React 19+ 使用新打包工具的环境
+ * Async: find debug source from Fiber
+ * When sync fails, try source-map resolution
+ * For Next.js 15+ / React 19+ with new bundlers
  */
 export async function findDebugSourceAsync(
   fiber: Fiber
 ): Promise<{ fiber: Fiber; source: Source } | null> {
-  // 1. 先尝试同步方式
+  // 1. Try synchronous method first
   const syncResult = findDebugSource(fiber);
   if (syncResult) {
     return syncResult;
@@ -136,12 +136,12 @@ export async function findDebugSourceAsync(
   const debug = isDebugEnabled();
   if (debug) {
     console.log(
-      "%c[LocatorJS] 同步方式未找到，尝试异步解析...",
+      "%c[LocatorJS] Sync methods failed, trying async resolution...",
       "color: #2196F3; font-style: italic"
     );
   }
 
-  // 2. 同步方式失败，尝试异步解析（通过 source-map）
+  // 2. Sync failed, try async resolution (via source-map)
   let current: Fiber | null = fiber;
   while (current) {
     const source = await resolveSourceFromFiber(current);

--- a/packages/runtime/src/adapters/react/findDebugSource.ts
+++ b/packages/runtime/src/adapters/react/findDebugSource.ts
@@ -52,7 +52,7 @@ function getSourceFromFiber(fiber: Fiber): [Source | null, SourceMethodType | nu
   // 6. Try from _debugInfo (React 19 Server Components)
   if (fiberAny._debugInfo && Array.isArray(fiberAny._debugInfo)) {
     for (const info of fiberAny._debugInfo) {
-      if (info.stack) {
+      if (info.stack && typeof info.stack === "string") {
         // Parse stack for first valid position
         const match = info.stack.match(/at\s+\S+\s+\(([^:]+):(\d+):(\d+)\)/);
         if (match) {
@@ -141,7 +141,7 @@ export async function findDebugSourceAsync(
     );
   }
 
-  // 2. Sync failed, try async resolution (via source-map)
+  // 2. Sync failed, try async resolution via _debugOwner chain
   let current: Fiber | null = fiber;
   while (current) {
     const source = await resolveSourceFromFiber(current);
@@ -149,6 +149,24 @@ export async function findDebugSourceAsync(
       return { fiber: current, source };
     }
     current = current._debugOwner || null;
+  }
+
+  // 3. _debugOwner chain exhausted — try fiber.return chain (actual parent tree)
+  // This catches cases where _debugOwner skips intermediate components
+  // (e.g. Server Component owns <p> directly, but <p> is rendered inside <Card>)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let parent: any = (fiber as any).return;
+  const visited = new Set<any>();
+  while (parent && !visited.has(parent)) {
+    visited.add(parent);
+    // Only try function components (tag 0 = FunctionComponent, tag 11 = ForwardRef)
+    if (typeof parent.type === "function") {
+      const source = await resolveSourceFromFiber(parent);
+      if (source) {
+        return { fiber: parent, source };
+      }
+    }
+    parent = parent.return;
   }
 
   if (debug) {

--- a/packages/runtime/src/adapters/react/findFiberByHtmlElement.ts
+++ b/packages/runtime/src/adapters/react/findFiberByHtmlElement.ts
@@ -2,18 +2,18 @@ import { Fiber, Renderer } from "@locator/shared";
 import { findDebugSource } from "./findDebugSource";
 
 /**
- * 从 DOM 元素直接获取 Fiber（适用于 React 17+，包括 React 19）
- * React 在 DOM 元素上存储了 __reactFiber$xxx 属性
+ * Get Fiber directly from DOM element (React 17+, including React 19)
+ * React stores __reactFiber$xxx property on DOM elements
  */
 function getFiberFromElement(element: HTMLElement): Fiber | null {
   const keys = Object.keys(element);
-  // React 17+ 使用 __reactFiber$ 前缀
+  // React 17+ uses __reactFiber$ prefix
   const fiberKey = keys.find((key) => key.startsWith("__reactFiber$"));
   if (fiberKey) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (element as any)[fiberKey] as Fiber;
   }
-  // React 16 使用 __reactInternalInstance$ 前缀
+  // React 16 uses __reactInternalInstance$ prefix
   const internalKey = keys.find((key) =>
     key.startsWith("__reactInternalInstance$")
   );
@@ -31,7 +31,7 @@ export function findFiberByHtmlElement(
   const renderers = window.__REACT_DEVTOOLS_GLOBAL_HOOK__?.renderers;
   const renderersValues = renderers?.values();
 
-  // 优先使用 renderer.findFiberByHostInstance（React 18 及更早版本）
+  // Prefer renderer.findFiberByHostInstance (React 18 and earlier)
   if (renderersValues) {
     for (const renderer of Array.from(renderersValues) as Renderer[]) {
       if (renderer.findFiberByHostInstance) {
@@ -48,7 +48,7 @@ export function findFiberByHtmlElement(
     }
   }
 
-  // 回退方案：直接从 DOM 元素获取 Fiber（React 19+ 或 DevTools 未安装时）
+  // Fallback: get Fiber directly from DOM (React 19+ or DevTools not installed)
   const fiber = getFiberFromElement(target);
   if (fiber) {
     if (shouldHaveDebugSource) {

--- a/packages/runtime/src/adapters/react/findFiberByHtmlElement.ts
+++ b/packages/runtime/src/adapters/react/findFiberByHtmlElement.ts
@@ -1,13 +1,37 @@
 import { Fiber, Renderer } from "@locator/shared";
 import { findDebugSource } from "./findDebugSource";
 
+/**
+ * 从 DOM 元素直接获取 Fiber（适用于 React 17+，包括 React 19）
+ * React 在 DOM 元素上存储了 __reactFiber$xxx 属性
+ */
+function getFiberFromElement(element: HTMLElement): Fiber | null {
+  const keys = Object.keys(element);
+  // React 17+ 使用 __reactFiber$ 前缀
+  const fiberKey = keys.find((key) => key.startsWith("__reactFiber$"));
+  if (fiberKey) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (element as any)[fiberKey] as Fiber;
+  }
+  // React 16 使用 __reactInternalInstance$ 前缀
+  const internalKey = keys.find((key) =>
+    key.startsWith("__reactInternalInstance$")
+  );
+  if (internalKey) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (element as any)[internalKey] as Fiber;
+  }
+  return null;
+}
+
 export function findFiberByHtmlElement(
   target: HTMLElement,
   shouldHaveDebugSource: boolean
 ): Fiber | null {
   const renderers = window.__REACT_DEVTOOLS_GLOBAL_HOOK__?.renderers;
-  // console.log("RENDERERS: ", renderers);
   const renderersValues = renderers?.values();
+
+  // 优先使用 renderer.findFiberByHostInstance（React 18 及更早版本）
   if (renderersValues) {
     for (const renderer of Array.from(renderersValues) as Renderer[]) {
       if (renderer.findFiberByHostInstance) {
@@ -23,5 +47,16 @@ export function findFiberByHtmlElement(
       }
     }
   }
+
+  // 回退方案：直接从 DOM 元素获取 Fiber（React 19+ 或 DevTools 未安装时）
+  const fiber = getFiberFromElement(target);
+  if (fiber) {
+    if (shouldHaveDebugSource) {
+      return findDebugSource(fiber)?.fiber || null;
+    } else {
+      return fiber;
+    }
+  }
+
   return null;
 }

--- a/packages/runtime/src/adapters/react/makeFiberId.tsx
+++ b/packages/runtime/src/adapters/react/makeFiberId.tsx
@@ -8,7 +8,7 @@ export function makeFiberId(fiber: Fiber) {
     return fiber._debugID.toString();
   }
   
-  // 验证 fiber 是有效对象，避免 WeakMap 键无效错误
+  // Validate fiber is a valid object to avoid invalid WeakMap key errors
   if (typeof fiber !== 'object' || fiber === null) {
     globalIdCounter++;
     return `fiber:${globalIdCounter}`;

--- a/packages/runtime/src/adapters/react/makeFiberId.tsx
+++ b/packages/runtime/src/adapters/react/makeFiberId.tsx
@@ -7,6 +7,13 @@ export function makeFiberId(fiber: Fiber) {
   if (fiber._debugID) {
     return fiber._debugID.toString();
   }
+  
+  // 验证 fiber 是有效对象，避免 WeakMap 键无效错误
+  if (typeof fiber !== 'object' || fiber === null) {
+    globalIdCounter++;
+    return `fiber:${globalIdCounter}`;
+  }
+  
   const found = globalIdMap.get(fiber);
   if (found) {
     return found;

--- a/packages/runtime/src/adapters/react/reactAdapter.ts
+++ b/packages/runtime/src/adapters/react/reactAdapter.ts
@@ -18,7 +18,6 @@ import { TreeNode, TreeNodeComponent } from "../../types/TreeNode";
 import { goUpByTheTree } from "../goUpByTheTree";
 import { HtmlElementTreeNode } from "../HtmlElementTreeNode";
 import { registerDiagnose } from "./debug";
-import { resolveSourceFromFiber } from "./clickSourceResolver";
 
 export function getElementInfo(found: HTMLElement): FullElementInfo | null {
   // Instead of labels, return this element, parent elements leading to closest component, its component labels, all wrapping components labels.
@@ -246,28 +245,15 @@ async function diagnoseAllElements(): Promise<void> {
       ? `${syncResult.source.fileName}:${syncResult.source.lineNumber}:${syncResult.source.columnNumber ?? 0}`
       : "none";
 
-    // Async source (directly on this fiber, no chain walking)
+    // Async source (tries fiber directly, then _debugOwner chain, then fiber.return chain)
     let asyncStr = "none";
     try {
-      const asyncResult = await resolveSourceFromFiber(fiber);
-      if (asyncResult) {
-        asyncStr = `${asyncResult.fileName}:${asyncResult.lineNumber}:${asyncResult.columnNumber ?? 0}`;
+      const asyncResult = await findDebugSourceAsync(fiber);
+      if (asyncResult?.source) {
+        asyncStr = `${asyncResult.source.fileName}:${asyncResult.source.lineNumber}:${asyncResult.source.columnNumber ?? 0}`;
       }
     } catch {
       asyncStr = "error";
-    }
-
-    // Full async with chain walking
-    let fullAsyncStr = asyncStr;
-    if (asyncStr === "none") {
-      try {
-        const fullResult = await findDebugSourceAsync(fiber);
-        if (fullResult?.source) {
-          fullAsyncStr = `${fullResult.source.fileName}:${fullResult.source.lineNumber}:${fullResult.source.columnNumber ?? 0}`;
-        }
-      } catch {
-        fullAsyncStr = "error";
-      }
     }
 
     rows.push({
@@ -275,7 +261,7 @@ async function diagnoseAllElements(): Promise<void> {
       text: textContent,
       hasFiber: true,
       syncSource: syncStr,
-      asyncSource: fullAsyncStr,
+      asyncSource: asyncStr,
     });
   }
 

--- a/packages/runtime/src/adapters/react/reactAdapter.ts
+++ b/packages/runtime/src/adapters/react/reactAdapter.ts
@@ -138,8 +138,8 @@ function getParentsPaths(element: HTMLElement) {
 }
 
 /**
- * 异步版本的 getElementInfo
- * 当同步方式无法获取 source 时，尝试通过 source-map 解析
+ * Async version of getElementInfo
+ * When sync cannot get source, try source-map resolution
  */
 export async function getElementInfoAsync(
   found: HTMLElement
@@ -153,7 +153,7 @@ export async function getElementInfoAsync(
 
     const allPotentialComponentFibers = getAllWrappingParents(component);
 
-    // 使用异步方式获取 source
+    // Use async method to get source
     for (const f of allPotentialComponentFibers) {
       const fiberWithSource = await findDebugSourceAsync(f);
       if (fiberWithSource) {
@@ -165,7 +165,7 @@ export async function getElementInfoAsync(
       }
     }
 
-    // 获取当前元素的 source（异步）
+    // Get current element's source (async)
     const currentSource = await findDebugSourceAsync(fiber);
     const thisLabel = getFiberLabel(fiber, currentSource?.source);
 

--- a/packages/runtime/src/adapters/react/reactAdapter.ts
+++ b/packages/runtime/src/adapters/react/reactAdapter.ts
@@ -17,6 +17,8 @@ import { Fiber, Source } from "@locator/shared";
 import { TreeNode, TreeNodeComponent } from "../../types/TreeNode";
 import { goUpByTheTree } from "../goUpByTheTree";
 import { HtmlElementTreeNode } from "../HtmlElementTreeNode";
+import { registerDiagnose } from "./debug";
+import { resolveSourceFromFiber } from "./clickSourceResolver";
 
 export function getElementInfo(found: HTMLElement): FullElementInfo | null {
   // Instead of labels, return this element, parent elements leading to closest component, its component labels, all wrapping components labels.
@@ -187,6 +189,113 @@ export async function getElementInfoAsync(
 
   return null;
 }
+
+/**
+ * Walk all DOM elements and log debug info + resolved source for each.
+ * Exposed as window.locatorDiagnose()
+ */
+async function diagnoseAllElements(): Promise<void> {
+  const root = document.querySelector("main") || document.body;
+  const allElements = root.querySelectorAll("*");
+
+  interface DiagnoseRow {
+    element: string;
+    text: string;
+    hasFiber: boolean;
+    syncSource: string;
+    asyncSource: string;
+  }
+
+  const rows: DiagnoseRow[] = [];
+
+  console.log(
+    `%c[LocatorJS-diag] Scanning ${allElements.length} elements...`,
+    "color: #FF9800; font-weight: bold"
+  );
+
+  for (const el of Array.from(allElements)) {
+    if (!(el instanceof HTMLElement)) continue;
+
+    // Skip LocatorJS own UI elements
+    if (el.closest("[data-locatorjs]") || el.id === "locatorjs-wrapper") continue;
+
+    const tag = el.tagName.toLowerCase();
+    const id = el.id ? `#${el.id}` : "";
+    const cls = el.className && typeof el.className === "string"
+      ? `.${el.className.split(/\s+/).filter(Boolean).join(".")}`
+      : "";
+    const label = `<${tag}${id}${cls}>`;
+
+    const textContent = el.textContent?.trim().slice(0, 40) || "";
+
+    const fiber = findFiberByHtmlElement(el, false);
+    if (!fiber) {
+      rows.push({
+        element: label,
+        text: textContent,
+        hasFiber: false,
+        syncSource: "-",
+        asyncSource: "-",
+      });
+      continue;
+    }
+
+    // Sync source
+    const syncResult = findDebugSource(fiber);
+    const syncStr = syncResult?.source
+      ? `${syncResult.source.fileName}:${syncResult.source.lineNumber}:${syncResult.source.columnNumber ?? 0}`
+      : "none";
+
+    // Async source (directly on this fiber, no chain walking)
+    let asyncStr = "none";
+    try {
+      const asyncResult = await resolveSourceFromFiber(fiber);
+      if (asyncResult) {
+        asyncStr = `${asyncResult.fileName}:${asyncResult.lineNumber}:${asyncResult.columnNumber ?? 0}`;
+      }
+    } catch {
+      asyncStr = "error";
+    }
+
+    // Full async with chain walking
+    let fullAsyncStr = asyncStr;
+    if (asyncStr === "none") {
+      try {
+        const fullResult = await findDebugSourceAsync(fiber);
+        if (fullResult?.source) {
+          fullAsyncStr = `${fullResult.source.fileName}:${fullResult.source.lineNumber}:${fullResult.source.columnNumber ?? 0}`;
+        }
+      } catch {
+        fullAsyncStr = "error";
+      }
+    }
+
+    rows.push({
+      element: label,
+      text: textContent,
+      hasFiber: true,
+      syncSource: syncStr,
+      asyncSource: fullAsyncStr,
+    });
+  }
+
+  console.log(
+    `%c[LocatorJS-diag] Results:`,
+    "color: #4CAF50; font-weight: bold"
+  );
+  console.table(rows);
+
+  // Summary
+  const withFiber = rows.filter((r) => r.hasFiber);
+  const resolved = withFiber.filter((r) => r.asyncSource !== "none" && r.asyncSource !== "-" && r.asyncSource !== "error");
+  console.log(
+    `%c[LocatorJS-diag] Summary: ${rows.length} elements, ${withFiber.length} with fiber, ${resolved.length} resolved`,
+    "color: #2196F3; font-weight: bold"
+  );
+}
+
+// Register diagnose so it's available as window.locatorDiagnose()
+registerDiagnose(diagnoseAllElements);
 
 const reactAdapter: AdapterObject = {
   getElementInfo,

--- a/packages/runtime/src/adapters/react/reactAdapter.ts
+++ b/packages/runtime/src/adapters/react/reactAdapter.ts
@@ -1,4 +1,4 @@
-import { findDebugSource } from "./findDebugSource";
+import { findDebugSource, findDebugSourceAsync } from "./findDebugSource";
 import { findFiberByHtmlElement } from "./findFiberByHtmlElement";
 import { getFiberLabel } from "./getFiberLabel";
 import { getAllWrappingParents } from "./getAllWrappingParents";
@@ -71,13 +71,11 @@ export function getElementInfo(found: HTMLElement): FullElementInfo | null {
 export class ReactTreeNodeElement extends HtmlElementTreeNode {
   getSource(): Source | null {
     const fiber = findFiberByHtmlElement(this.element, false);
-
-    if (fiber && fiber._debugSource) {
-      return {
-        fileName: fiber._debugSource.fileName,
-        lineNumber: fiber._debugSource.lineNumber,
-        columnNumber: fiber._debugSource.columnNumber,
-      };
+    if (fiber) {
+      const result = findDebugSource(fiber);
+      if (result) {
+        return result.source;
+      }
     }
     return null;
   }
@@ -137,6 +135,57 @@ function getParentsPaths(element: HTMLElement) {
     return pathItems;
   }
   return [];
+}
+
+/**
+ * 异步版本的 getElementInfo
+ * 当同步方式无法获取 source 时，尝试通过 source-map 解析
+ */
+export async function getElementInfoAsync(
+  found: HTMLElement
+): Promise<FullElementInfo | null> {
+  const labels: LabelData[] = [];
+
+  const fiber = findFiberByHtmlElement(found, false);
+  if (fiber) {
+    const { component, componentBox, parentElements } =
+      getAllParentsElementsAndRootComponent(fiber);
+
+    const allPotentialComponentFibers = getAllWrappingParents(component);
+
+    // 使用异步方式获取 source
+    for (const f of allPotentialComponentFibers) {
+      const fiberWithSource = await findDebugSourceAsync(f);
+      if (fiberWithSource) {
+        const label = getFiberLabel(
+          fiberWithSource.fiber,
+          fiberWithSource.source
+        );
+        labels.push(label);
+      }
+    }
+
+    // 获取当前元素的 source（异步）
+    const currentSource = await findDebugSourceAsync(fiber);
+    const thisLabel = getFiberLabel(fiber, currentSource?.source);
+
+    if (isStyledElement(fiber)) {
+      thisLabel.label = `${thisLabel.label} (styled)`;
+    }
+
+    return {
+      thisElement: {
+        box: getFiberOwnBoundingBox(fiber) || found.getBoundingClientRect(),
+        ...thisLabel,
+      },
+      htmlElement: found,
+      parentElements: parentElements,
+      componentBox,
+      componentsLabels: deduplicateLabels(labels),
+    };
+  }
+
+  return null;
 }
 
 const reactAdapter: AdapterObject = {

--- a/packages/runtime/src/adapters/react/sourceMapResolver.test.ts
+++ b/packages/runtime/src/adapters/react/sourceMapResolver.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest";
+import { decodeVLQ, parseMappings, fileUrlToPath } from "./sourceMapResolver";
+
+describe("decodeVLQ", () => {
+  test("decodes zero (A)", () => {
+    const [value, nextIndex] = decodeVLQ("A", 0);
+    expect(value).toBe(0);
+    expect(nextIndex).toBe(1);
+  });
+
+  test("decodes positive values", () => {
+    // 'C' = 2 -> value = 1 (positive)
+    const [value] = decodeVLQ("C", 0);
+    expect(value).toBe(1);
+  });
+
+  test("decodes negative values", () => {
+    // 'D' = 3 -> value = -1 (negative, sign bit set)
+    const [value] = decodeVLQ("D", 0);
+    expect(value).toBe(-1);
+  });
+
+  test("decodes multi-character VLQ", () => {
+    // 'gB' -> continuation bit set on first char
+    // 'g' = 32 (index in base64), continuation=1, bits=0b00000 -> partial
+    // Actually let's test with a known value
+    // To encode 16: 16 << 1 = 32, which needs continuation
+    // 32 = 0b100000 -> first char: continuation(1) | 0b00000 = 0b100000 = 32 = 'g'
+    // remaining: 1 -> 0b00001 = 1 = 'B'
+    const [value] = decodeVLQ("gB", 0);
+    expect(value).toBe(16);
+  });
+
+  test("respects starting index", () => {
+    const [value, nextIndex] = decodeVLQ("XAC", 1);
+    expect(value).toBe(0); // 'A' = 0
+    expect(nextIndex).toBe(2);
+  });
+
+  test("throws on unexpected end", () => {
+    // 'g' has continuation bit set but string ends
+    expect(() => decodeVLQ("g", 0)).toThrow("Unexpected end of VLQ");
+  });
+
+  test("throws on invalid character", () => {
+    expect(() => decodeVLQ("!", 0)).toThrow("Invalid VLQ character");
+  });
+});
+
+describe("parseMappings", () => {
+  test("parses empty string", () => {
+    const result = parseMappings("");
+    expect(result).toEqual([]);
+  });
+
+  test("parses single semicolon (empty line)", () => {
+    const result = parseMappings(";");
+    // One empty line, then potentially another
+    expect(result.length).toBeGreaterThanOrEqual(1);
+    expect(result[0]).toEqual([]);
+  });
+
+  test("parses single segment with 4 fields", () => {
+    // AAAA = generatedCol:0, sourceIdx:0, origLine:0, origCol:0
+    const result = parseMappings("AAAA");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(1);
+    expect(result[0]![0]).toEqual({
+      generatedColumn: 0,
+      sourceIndex: 0,
+      originalLine: 0,
+      originalColumn: 0,
+    });
+  });
+
+  test("parses multiple segments on same line", () => {
+    // AAAA,CACA = two segments separated by comma
+    const result = parseMappings("AAAA,CACA");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toHaveLength(2);
+    // First segment: 0,0,0,0
+    expect(result[0]![0]!.generatedColumn).toBe(0);
+    // Second segment: relative values added
+    expect(result[0]![1]!.generatedColumn).toBe(1); // C=1 relative to 0
+  });
+
+  test("parses multiple lines", () => {
+    // AAAA;AAAA = one segment per line
+    const result = parseMappings("AAAA;AAAA");
+    expect(result).toHaveLength(2);
+    expect(result[0]).toHaveLength(1);
+    expect(result[1]).toHaveLength(1);
+    // Generated column resets per line, but source/line/column are relative across lines
+    expect(result[1]![0]!.generatedColumn).toBe(0);
+  });
+
+  test("handles relative values correctly across segments", () => {
+    // AACA = genCol:0, srcIdx:0, origLine:1, origCol:0
+    // then ;AACA = genCol:0, srcIdx:0, origLine:+1=2, origCol:0
+    const result = parseMappings("AACA;AACA");
+    expect(result[0]![0]!.originalLine).toBe(1);
+    expect(result[1]![0]!.originalLine).toBe(2); // 1 + 1 = 2
+  });
+});
+
+describe("fileUrlToPath", () => {
+  test("converts Unix file:// URL to path", () => {
+    expect(fileUrlToPath("file:///Users/foo/bar.ts")).toBe(
+      "/Users/foo/bar.ts"
+    );
+  });
+
+  test("converts Windows file:// URL to path", () => {
+    expect(fileUrlToPath("file:///C:/foo/bar.ts")).toBe("C:/foo/bar.ts");
+  });
+
+  test("decodes URL-encoded characters", () => {
+    expect(fileUrlToPath("file:///Users/foo%40bar/baz.ts")).toBe(
+      "/Users/foo@bar/baz.ts"
+    );
+  });
+
+  test("passes through non-file:// URLs unchanged", () => {
+    expect(fileUrlToPath("/Users/foo/bar.ts")).toBe("/Users/foo/bar.ts");
+    expect(fileUrlToPath("https://example.com/foo.ts")).toBe(
+      "https://example.com/foo.ts"
+    );
+  });
+
+  test("handles file:// URL with spaces", () => {
+    expect(fileUrlToPath("file:///Users/foo%20bar/baz.ts")).toBe(
+      "/Users/foo bar/baz.ts"
+    );
+  });
+});

--- a/packages/runtime/src/adapters/react/sourceMapResolver.ts
+++ b/packages/runtime/src/adapters/react/sourceMapResolver.ts
@@ -1,18 +1,18 @@
 import { Source } from "@locator/shared";
 
 /**
- * Source Map 解析器
- * 用于 Next.js 15+ / React 19+ 使用 Turbopack 打包的环境
- * 当传统 _debugSource 方式失效时，通过 source-map 反查原始位置
+ * Source Map Resolver
+ * For Next.js 15+ / React 19+ using Turbopack
+ * When traditional _debugSource is unavailable, reverse-lookup via source-map
  */
 
-// source-map 缓存：url -> 解析后的 map 数据
+// Source map cache: url -> parsed map data
 const sourceMapCache = new Map<string, SourceMapConsumer | null>();
 
-// 正在加载的 source-map Promise 缓存，避免重复请求
+// Loading promise cache to avoid duplicate requests
 const loadingPromises = new Map<string, Promise<SourceMapConsumer | null>>();
 
-// 简化的 Source Map Consumer 接口
+// Simplified Source Map Consumer interface
 interface SourceMapConsumer {
   originalPositionFor(pos: {
     line: number;
@@ -31,17 +31,17 @@ interface RawSourceMap {
   sourceRoot?: string;
 }
 
-// Indexed Source Map 格式（Turbopack 使用）
+// Indexed Source Map format (used by Turbopack)
 interface IndexedSourceMap {
   version: number;
-  sources: string[]; // 顶层为空
+  sources: string[]; // empty at top level
   sections: Array<{
     offset: { line: number; column: number };
     map: RawSourceMap;
   }>;
 }
 
-// VLQ 解码表
+// VLQ decoding table
 const VLQ_BASE_SHIFT = 5;
 const VLQ_BASE = 1 << VLQ_BASE_SHIFT;
 const VLQ_BASE_MASK = VLQ_BASE - 1;
@@ -55,9 +55,9 @@ const charToInt: Record<string, number> = {};
   });
 
 /**
- * 解码 VLQ 编码的值
+ * Decode a VLQ-encoded value
  */
-function decodeVLQ(encoded: string, index: number): [number, number] {
+export function decodeVLQ(encoded: string, index: number): [number, number] {
   let result = 0;
   let shift = 0;
   let continuation: boolean;
@@ -76,13 +76,13 @@ function decodeVLQ(encoded: string, index: number): [number, number] {
     shift += VLQ_BASE_SHIFT;
   } while (continuation);
 
-  // 符号位在最低位
+  // Sign bit is in the least significant position
   const isNegative = result & 1;
   result >>= 1;
   return [isNegative ? -result : result, index];
 }
 
-interface MappingSegment {
+export interface MappingSegment {
   generatedColumn: number;
   sourceIndex: number;
   originalLine: number;
@@ -90,10 +90,10 @@ interface MappingSegment {
 }
 
 /**
- * 解析 source map mappings 字符串
- * 返回按行组织的映射数组
+ * Parse source map mappings string
+ * Returns mappings organized by generated line
  */
-function parseMappings(mappings: string): MappingSegment[][] {
+export function parseMappings(mappings: string): MappingSegment[][] {
   const lines: MappingSegment[][] = [];
 
   let generatedColumn = 0;
@@ -115,14 +115,14 @@ function parseMappings(mappings: string): MappingSegment[][] {
     } else if (char === ",") {
       i++;
     } else {
-      // 解析一个 segment
+      // Parse one segment
       let value: number;
 
-      // 1. generated column (相对于上一个 segment)
+      // 1. generated column (relative to previous segment)
       [value, i] = decodeVLQ(mappings, i);
       generatedColumn += value;
 
-      // 检查是否有更多字段
+      // Check if there are more fields
       if (i < mappings.length && mappings[i] !== "," && mappings[i] !== ";") {
         // 2. source index
         [value, i] = decodeVLQ(mappings, i);
@@ -136,7 +136,7 @@ function parseMappings(mappings: string): MappingSegment[][] {
         [value, i] = decodeVLQ(mappings, i);
         originalColumn += value;
 
-        // 5. name index (可选，忽略)
+        // 5. name index (optional, ignored)
         if (i < mappings.length && mappings[i] !== "," && mappings[i] !== ";") {
           [, i] = decodeVLQ(mappings, i);
         }
@@ -151,7 +151,7 @@ function parseMappings(mappings: string): MappingSegment[][] {
     }
   }
 
-  // 不要忘记最后一行
+  // Don't forget the last line
   if (currentLine.length > 0 || mappings.endsWith(";")) {
     lines.push(currentLine);
   }
@@ -160,14 +160,14 @@ function parseMappings(mappings: string): MappingSegment[][] {
 }
 
 /**
- * 创建简易 Source Map Consumer（普通格式）
+ * Create a basic Source Map Consumer (standard format)
  */
 function createBasicSourceMapConsumer(rawMap: RawSourceMap): SourceMapConsumer {
   const parsedMappings = parseMappings(rawMap.mappings);
 
   return {
     originalPositionFor(pos: { line: number; column: number }) {
-      // line 是 1-based，转为 0-based 索引
+      // line is 1-based, convert to 0-based index
       const lineIndex = pos.line - 1;
       const segments = parsedMappings[lineIndex];
 
@@ -175,7 +175,7 @@ function createBasicSourceMapConsumer(rawMap: RawSourceMap): SourceMapConsumer {
         return { source: null, line: null, column: null };
       }
 
-      // 二分查找最接近的 segment
+      // Binary search for closest segment
       let low = 0;
       let high = segments.length - 1;
 
@@ -199,14 +199,14 @@ function createBasicSourceMapConsumer(rawMap: RawSourceMap): SourceMapConsumer {
         return { source: null, line: null, column: null };
       }
 
-      // 处理 sourceRoot
+      // Handle sourceRoot
       const fullSource = rawMap.sourceRoot
         ? `${rawMap.sourceRoot}${source}`
         : source;
 
       return {
         source: fullSource,
-        line: segment.originalLine + 1, // 转回 1-based
+        line: segment.originalLine + 1, // Convert back to 1-based
         column: segment.originalColumn,
       };
     },
@@ -214,11 +214,11 @@ function createBasicSourceMapConsumer(rawMap: RawSourceMap): SourceMapConsumer {
 }
 
 /**
- * 创建 Indexed Source Map Consumer（Turbopack 格式）
- * sections 按 offset 排序，每个 section 有自己的 map
+ * Create Indexed Source Map Consumer (Turbopack format)
+ * Sections sorted by offset, each has its own map
  */
 function createIndexedSourceMapConsumer(indexedMap: IndexedSourceMap): SourceMapConsumer {
-  // 预解析所有 section 的 mappings
+  // Pre-parse all section mappings
   const sectionConsumers = indexedMap.sections.map(section => ({
     offset: section.offset,
     consumer: createBasicSourceMapConsumer(section.map),
@@ -227,15 +227,15 @@ function createIndexedSourceMapConsumer(indexedMap: IndexedSourceMap): SourceMap
 
   return {
     originalPositionFor(pos: { line: number; column: number }) {
-      // 找到包含该位置的 section（从后往前找，找第一个 offset <= pos 的）
+      // Find section containing position (search backward for first offset <= pos)
       let targetSection: typeof sectionConsumers[0] | null = null;
       for (let i = sectionConsumers.length - 1; i >= 0; i--) {
         const section = sectionConsumers[i];
         if (!section) continue;
-        // offset.line 是 0-based，pos.line 是 1-based
+        // offset.line is 0-based, pos.line is 1-based
         const sectionStartLine = section.offset.line + 1;
         if (pos.line >= sectionStartLine) {
-          // 如果在同一行，还需要检查 column
+          // On same line, also check column
           if (pos.line === sectionStartLine && pos.column < section.offset.column) {
             continue;
           }
@@ -248,7 +248,7 @@ function createIndexedSourceMapConsumer(indexedMap: IndexedSourceMap): SourceMap
         return { source: null, line: null, column: null };
       }
 
-      // 计算相对于 section 的位置
+      // Calculate position relative to section
       const relativePos = {
         line: pos.line - targetSection.offset.line,
         column: pos.line === targetSection.offset.line + 1
@@ -262,10 +262,10 @@ function createIndexedSourceMapConsumer(indexedMap: IndexedSourceMap): SourceMap
 }
 
 /**
- * 创建 Source Map Consumer（自动检测格式）
+ * Create Source Map Consumer (auto-detect format)
  */
 function createSourceMapConsumer(map: RawSourceMap | IndexedSourceMap): SourceMapConsumer {
-  // 检测是否是 Indexed Source Map
+  // Detect if this is an Indexed Source Map
   if ('sections' in map && Array.isArray(map.sections)) {
     return createIndexedSourceMapConsumer(map as IndexedSourceMap);
   }
@@ -273,17 +273,17 @@ function createSourceMapConsumer(map: RawSourceMap | IndexedSourceMap): SourceMa
 }
 
 /**
- * 从 URL 加载 source map
+ * Load source map from URL
  */
 async function loadSourceMap(
   mapUrl: string
 ): Promise<SourceMapConsumer | null> {
-  // 检查缓存
+  // Check cache
   if (sourceMapCache.has(mapUrl)) {
     return sourceMapCache.get(mapUrl) ?? null;
   }
 
-  // 检查是否正在加载
+  // Check if already loading
   const existing = loadingPromises.get(mapUrl);
   if (existing) {
     return existing;
@@ -314,10 +314,10 @@ async function loadSourceMap(
 }
 
 /**
- * 从 JS 文件 URL 推断 source map URL
+ * Infer source map URL from JS file URL
  */
 function inferSourceMapUrl(jsUrl: string): string | null {
-  // 处理各种打包工具的 source map 命名规则
+  // Handle various bundler source map naming conventions
   if (jsUrl.endsWith(".js")) {
     return `${jsUrl}.map`;
   }
@@ -325,8 +325,8 @@ function inferSourceMapUrl(jsUrl: string): string | null {
 }
 
 /**
- * 解析 Error stack trace 获取调用位置
- * 支持 Chrome/Firefox/Safari 格式
+ * Parse Error stack trace for call location
+ * Supports Chrome/Firefox/Safari formats
  */
 interface StackFrame {
   fileName: string;
@@ -340,8 +340,8 @@ function parseStackTrace(stack: string): StackFrame[] {
   const lines = stack.split("\n");
 
   for (const line of lines) {
-    // Chrome 格式: "    at functionName (file:line:column)"
-    // 或 "    at file:line:column"
+    // Chrome format: "    at functionName (file:line:column)"
+    // or "    at file:line:column"
     const chromeMatch = line.match(
       /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/
     );
@@ -358,7 +358,7 @@ function parseStackTrace(stack: string): StackFrame[] {
       continue;
     }
 
-    // Firefox 格式: "functionName@file:line:column"
+    // Firefox format: "functionName@file:line:column"
     const firefoxMatch = line.match(/^(.+?)@(.+?):(\d+):(\d+)$/);
     if (firefoxMatch) {
       const [, funcName, fileName, lineStr, colStr] = firefoxMatch;
@@ -377,14 +377,14 @@ function parseStackTrace(stack: string): StackFrame[] {
 }
 
 /**
- * 过滤掉 LocatorJS 自身和 React 内部的 stack frames
+ * Filter out LocatorJS and React internal stack frames
  */
 function filterRelevantFrames(frames: StackFrame[]): StackFrame[] {
   return frames.filter((frame) => {
     const fileName = frame.fileName.toLowerCase();
-    // 排除 LocatorJS 自身
+    // Exclude LocatorJS
     if (fileName.includes("locator")) return false;
-    // 排除 React 内部
+    // Exclude React internals
     if (fileName.includes("react-dom")) return false;
     if (fileName.includes("react.development")) return false;
     if (fileName.includes("react.production")) return false;
@@ -393,12 +393,12 @@ function filterRelevantFrames(frames: StackFrame[]): StackFrame[] {
 }
 
 /**
- * 尝试从 stack trace 获取组件源码位置
- * 这是核心函数，用于无法获取 _debugSource 的环境
+ * Try to get component source from stack trace
+ * Core function for environments where _debugSource is unavailable
  */
 export async function resolveSourceFromStack(): Promise<Source | null> {
   try {
-    // 生成一个 Error 获取 stack trace
+    // Generate Error to get stack trace
     const error = new Error();
     const stack = error.stack;
     if (!stack) return null;
@@ -408,14 +408,14 @@ export async function resolveSourceFromStack(): Promise<Source | null> {
 
     if (relevantFrames.length === 0) return null;
 
-    // 取第一个相关的 frame（通常是组件渲染位置）
+    // Take first relevant frame (usually component render location)
     const frame = relevantFrames[0];
     if (!frame) return null;
 
     const mapUrl = inferSourceMapUrl(frame.fileName);
 
     if (!mapUrl) {
-      // 没有 source map，直接返回编译后的位置
+      // No source map, return compiled position
       return {
         fileName: frame.fileName,
         lineNumber: frame.lineNumber,
@@ -423,7 +423,7 @@ export async function resolveSourceFromStack(): Promise<Source | null> {
       };
     }
 
-    // 加载并解析 source map
+    // Load and parse source map
     const consumer = await loadSourceMap(mapUrl);
     if (!consumer) {
       return {
@@ -457,26 +457,26 @@ export async function resolveSourceFromStack(): Promise<Source | null> {
 }
 
 /**
- * 将 file:// URL 转换为本地路径
+ * Convert file:// URL to local path
  * file:///Users/foo/bar.ts -> /Users/foo/bar.ts
  * file:///C:/foo/bar.ts -> C:/foo/bar.ts (Windows)
  */
-function fileUrlToPath(fileUrl: string): string {
+export function fileUrlToPath(fileUrl: string): string {
   if (!fileUrl.startsWith('file://')) {
     return fileUrl;
   }
 
-  // 移除 file:// 前缀
+  // Remove file:// prefix
   let path = fileUrl.slice(7);
 
-  // URL 解码（处理 %40 -> @ 等）
+  // URL decode (handle %40 -> @ etc.)
   try {
     path = decodeURIComponent(path);
   } catch {
-    // 解码失败则保持原样
+    // Keep original if decoding fails
   }
 
-  // Windows 路径处理：file:///C:/foo -> C:/foo
+  // Windows path handling: file:///C:/foo -> C:/foo
   if (path.match(/^\/[A-Za-z]:\//)) {
     path = path.slice(1);
   }
@@ -485,7 +485,7 @@ function fileUrlToPath(fileUrl: string): string {
 }
 
 /**
- * 从指定的编译后位置反查原始位置
+ * Reverse-lookup original position from compiled position
  */
 export async function resolveOriginalPosition(
   compiledUrl: string,
@@ -505,7 +505,7 @@ export async function resolveOriginalPosition(
   const original = consumer.originalPositionFor({ line, column });
 
   if (original.source && original.line) {
-    // 转换 file:// URL 为本地路径
+    // Convert file:// URL to local path
     const fileName = fileUrlToPath(original.source);
     return {
       fileName,
@@ -518,10 +518,10 @@ export async function resolveOriginalPosition(
 }
 
 /**
- * 预加载页面上所有 chunk 的 source map（可选优化）
+ * Preload source maps for all page chunks (optional optimization)
  */
 export async function preloadSourceMaps(): Promise<void> {
-  // 查找页面上所有的 script 标签
+  // Find all script tags on page
   const scripts = document.querySelectorAll('script[src*=".js"]');
   const loadPromises: Promise<void>[] = [];
 
@@ -541,7 +541,7 @@ export async function preloadSourceMaps(): Promise<void> {
 }
 
 /**
- * 清除 source map 缓存
+ * Clear source map cache
  */
 export function clearSourceMapCache(): void {
   sourceMapCache.clear();

--- a/packages/runtime/src/adapters/react/sourceMapResolver.ts
+++ b/packages/runtime/src/adapters/react/sourceMapResolver.ts
@@ -1,0 +1,549 @@
+import { Source } from "@locator/shared";
+
+/**
+ * Source Map 解析器
+ * 用于 Next.js 15+ / React 19+ 使用 Turbopack 打包的环境
+ * 当传统 _debugSource 方式失效时，通过 source-map 反查原始位置
+ */
+
+// source-map 缓存：url -> 解析后的 map 数据
+const sourceMapCache = new Map<string, SourceMapConsumer | null>();
+
+// 正在加载的 source-map Promise 缓存，避免重复请求
+const loadingPromises = new Map<string, Promise<SourceMapConsumer | null>>();
+
+// 简化的 Source Map Consumer 接口
+interface SourceMapConsumer {
+  originalPositionFor(pos: {
+    line: number;
+    column: number;
+  }): { source: string | null; line: number | null; column: number | null };
+  destroy?: () => void;
+}
+
+interface RawSourceMap {
+  version: number;
+  sources: string[];
+  sourcesContent?: string[];
+  mappings: string;
+  names?: string[];
+  file?: string;
+  sourceRoot?: string;
+}
+
+// Indexed Source Map 格式（Turbopack 使用）
+interface IndexedSourceMap {
+  version: number;
+  sources: string[]; // 顶层为空
+  sections: Array<{
+    offset: { line: number; column: number };
+    map: RawSourceMap;
+  }>;
+}
+
+// VLQ 解码表
+const VLQ_BASE_SHIFT = 5;
+const VLQ_BASE = 1 << VLQ_BASE_SHIFT;
+const VLQ_BASE_MASK = VLQ_BASE - 1;
+const VLQ_CONTINUATION_BIT = VLQ_BASE;
+
+const charToInt: Record<string, number> = {};
+"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+  .split("")
+  .forEach((char, i) => {
+    charToInt[char] = i;
+  });
+
+/**
+ * 解码 VLQ 编码的值
+ */
+function decodeVLQ(encoded: string, index: number): [number, number] {
+  let result = 0;
+  let shift = 0;
+  let continuation: boolean;
+
+  do {
+    const char = encoded[index++];
+    if (char === undefined) {
+      throw new Error("Unexpected end of VLQ");
+    }
+    const digit = charToInt[char];
+    if (digit === undefined) {
+      throw new Error(`Invalid VLQ character: ${char}`);
+    }
+    continuation = (digit & VLQ_CONTINUATION_BIT) !== 0;
+    result += (digit & VLQ_BASE_MASK) << shift;
+    shift += VLQ_BASE_SHIFT;
+  } while (continuation);
+
+  // 符号位在最低位
+  const isNegative = result & 1;
+  result >>= 1;
+  return [isNegative ? -result : result, index];
+}
+
+interface MappingSegment {
+  generatedColumn: number;
+  sourceIndex: number;
+  originalLine: number;
+  originalColumn: number;
+}
+
+/**
+ * 解析 source map mappings 字符串
+ * 返回按行组织的映射数组
+ */
+function parseMappings(mappings: string): MappingSegment[][] {
+  const lines: MappingSegment[][] = [];
+
+  let generatedColumn = 0;
+  let sourceIndex = 0;
+  let originalLine = 0;
+  let originalColumn = 0;
+
+  let currentLine: MappingSegment[] = [];
+  let i = 0;
+
+  while (i < mappings.length) {
+    const char = mappings[i];
+
+    if (char === ";") {
+      lines.push(currentLine);
+      currentLine = [];
+      generatedColumn = 0;
+      i++;
+    } else if (char === ",") {
+      i++;
+    } else {
+      // 解析一个 segment
+      let value: number;
+
+      // 1. generated column (相对于上一个 segment)
+      [value, i] = decodeVLQ(mappings, i);
+      generatedColumn += value;
+
+      // 检查是否有更多字段
+      if (i < mappings.length && mappings[i] !== "," && mappings[i] !== ";") {
+        // 2. source index
+        [value, i] = decodeVLQ(mappings, i);
+        sourceIndex += value;
+
+        // 3. original line
+        [value, i] = decodeVLQ(mappings, i);
+        originalLine += value;
+
+        // 4. original column
+        [value, i] = decodeVLQ(mappings, i);
+        originalColumn += value;
+
+        // 5. name index (可选，忽略)
+        if (i < mappings.length && mappings[i] !== "," && mappings[i] !== ";") {
+          [, i] = decodeVLQ(mappings, i);
+        }
+
+        currentLine.push({
+          generatedColumn,
+          sourceIndex,
+          originalLine,
+          originalColumn,
+        });
+      }
+    }
+  }
+
+  // 不要忘记最后一行
+  if (currentLine.length > 0 || mappings.endsWith(";")) {
+    lines.push(currentLine);
+  }
+
+  return lines;
+}
+
+/**
+ * 创建简易 Source Map Consumer（普通格式）
+ */
+function createBasicSourceMapConsumer(rawMap: RawSourceMap): SourceMapConsumer {
+  const parsedMappings = parseMappings(rawMap.mappings);
+
+  return {
+    originalPositionFor(pos: { line: number; column: number }) {
+      // line 是 1-based，转为 0-based 索引
+      const lineIndex = pos.line - 1;
+      const segments = parsedMappings[lineIndex];
+
+      if (!segments || segments.length === 0) {
+        return { source: null, line: null, column: null };
+      }
+
+      // 二分查找最接近的 segment
+      let low = 0;
+      let high = segments.length - 1;
+
+      while (low < high) {
+        const mid = Math.ceil((low + high) / 2);
+        const midSegment = segments[mid];
+        if (midSegment && midSegment.generatedColumn <= pos.column) {
+          low = mid;
+        } else {
+          high = mid - 1;
+        }
+      }
+
+      const segment = segments[low];
+      if (!segment || segment.generatedColumn > pos.column) {
+        return { source: null, line: null, column: null };
+      }
+
+      const source = rawMap.sources[segment.sourceIndex];
+      if (!source) {
+        return { source: null, line: null, column: null };
+      }
+
+      // 处理 sourceRoot
+      const fullSource = rawMap.sourceRoot
+        ? `${rawMap.sourceRoot}${source}`
+        : source;
+
+      return {
+        source: fullSource,
+        line: segment.originalLine + 1, // 转回 1-based
+        column: segment.originalColumn,
+      };
+    },
+  };
+}
+
+/**
+ * 创建 Indexed Source Map Consumer（Turbopack 格式）
+ * sections 按 offset 排序，每个 section 有自己的 map
+ */
+function createIndexedSourceMapConsumer(indexedMap: IndexedSourceMap): SourceMapConsumer {
+  // 预解析所有 section 的 mappings
+  const sectionConsumers = indexedMap.sections.map(section => ({
+    offset: section.offset,
+    consumer: createBasicSourceMapConsumer(section.map),
+    map: section.map,
+  }));
+
+  return {
+    originalPositionFor(pos: { line: number; column: number }) {
+      // 找到包含该位置的 section（从后往前找，找第一个 offset <= pos 的）
+      let targetSection: typeof sectionConsumers[0] | null = null;
+      for (let i = sectionConsumers.length - 1; i >= 0; i--) {
+        const section = sectionConsumers[i];
+        if (!section) continue;
+        // offset.line 是 0-based，pos.line 是 1-based
+        const sectionStartLine = section.offset.line + 1;
+        if (pos.line >= sectionStartLine) {
+          // 如果在同一行，还需要检查 column
+          if (pos.line === sectionStartLine && pos.column < section.offset.column) {
+            continue;
+          }
+          targetSection = section;
+          break;
+        }
+      }
+
+      if (!targetSection) {
+        return { source: null, line: null, column: null };
+      }
+
+      // 计算相对于 section 的位置
+      const relativePos = {
+        line: pos.line - targetSection.offset.line,
+        column: pos.line === targetSection.offset.line + 1
+          ? pos.column - targetSection.offset.column
+          : pos.column,
+      };
+
+      return targetSection.consumer.originalPositionFor(relativePos);
+    },
+  };
+}
+
+/**
+ * 创建 Source Map Consumer（自动检测格式）
+ */
+function createSourceMapConsumer(map: RawSourceMap | IndexedSourceMap): SourceMapConsumer {
+  // 检测是否是 Indexed Source Map
+  if ('sections' in map && Array.isArray(map.sections)) {
+    return createIndexedSourceMapConsumer(map as IndexedSourceMap);
+  }
+  return createBasicSourceMapConsumer(map as RawSourceMap);
+}
+
+/**
+ * 从 URL 加载 source map
+ */
+async function loadSourceMap(
+  mapUrl: string
+): Promise<SourceMapConsumer | null> {
+  // 检查缓存
+  if (sourceMapCache.has(mapUrl)) {
+    return sourceMapCache.get(mapUrl) ?? null;
+  }
+
+  // 检查是否正在加载
+  const existing = loadingPromises.get(mapUrl);
+  if (existing) {
+    return existing;
+  }
+
+  const loadPromise = (async () => {
+    try {
+      const response = await fetch(mapUrl);
+      if (!response.ok) {
+        sourceMapCache.set(mapUrl, null);
+        return null;
+      }
+
+      const rawMap: RawSourceMap = await response.json();
+      const consumer = createSourceMapConsumer(rawMap);
+      sourceMapCache.set(mapUrl, consumer);
+      return consumer;
+    } catch {
+      sourceMapCache.set(mapUrl, null);
+      return null;
+    } finally {
+      loadingPromises.delete(mapUrl);
+    }
+  })();
+
+  loadingPromises.set(mapUrl, loadPromise);
+  return loadPromise;
+}
+
+/**
+ * 从 JS 文件 URL 推断 source map URL
+ */
+function inferSourceMapUrl(jsUrl: string): string | null {
+  // 处理各种打包工具的 source map 命名规则
+  if (jsUrl.endsWith(".js")) {
+    return `${jsUrl}.map`;
+  }
+  return null;
+}
+
+/**
+ * 解析 Error stack trace 获取调用位置
+ * 支持 Chrome/Firefox/Safari 格式
+ */
+interface StackFrame {
+  fileName: string;
+  lineNumber: number;
+  columnNumber: number;
+  functionName?: string;
+}
+
+function parseStackTrace(stack: string): StackFrame[] {
+  const frames: StackFrame[] = [];
+  const lines = stack.split("\n");
+
+  for (const line of lines) {
+    // Chrome 格式: "    at functionName (file:line:column)"
+    // 或 "    at file:line:column"
+    const chromeMatch = line.match(
+      /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/
+    );
+    if (chromeMatch) {
+      const [, funcName, fileName, lineStr, colStr] = chromeMatch;
+      if (fileName && lineStr && colStr) {
+        frames.push({
+          functionName: funcName,
+          fileName,
+          lineNumber: parseInt(lineStr, 10),
+          columnNumber: parseInt(colStr, 10),
+        });
+      }
+      continue;
+    }
+
+    // Firefox 格式: "functionName@file:line:column"
+    const firefoxMatch = line.match(/^(.+?)@(.+?):(\d+):(\d+)$/);
+    if (firefoxMatch) {
+      const [, funcName, fileName, lineStr, colStr] = firefoxMatch;
+      if (fileName && lineStr && colStr) {
+        frames.push({
+          functionName: funcName,
+          fileName,
+          lineNumber: parseInt(lineStr, 10),
+          columnNumber: parseInt(colStr, 10),
+        });
+      }
+    }
+  }
+
+  return frames;
+}
+
+/**
+ * 过滤掉 LocatorJS 自身和 React 内部的 stack frames
+ */
+function filterRelevantFrames(frames: StackFrame[]): StackFrame[] {
+  return frames.filter((frame) => {
+    const fileName = frame.fileName.toLowerCase();
+    // 排除 LocatorJS 自身
+    if (fileName.includes("locator")) return false;
+    // 排除 React 内部
+    if (fileName.includes("react-dom")) return false;
+    if (fileName.includes("react.development")) return false;
+    if (fileName.includes("react.production")) return false;
+    return true;
+  });
+}
+
+/**
+ * 尝试从 stack trace 获取组件源码位置
+ * 这是核心函数，用于无法获取 _debugSource 的环境
+ */
+export async function resolveSourceFromStack(): Promise<Source | null> {
+  try {
+    // 生成一个 Error 获取 stack trace
+    const error = new Error();
+    const stack = error.stack;
+    if (!stack) return null;
+
+    const frames = parseStackTrace(stack);
+    const relevantFrames = filterRelevantFrames(frames);
+
+    if (relevantFrames.length === 0) return null;
+
+    // 取第一个相关的 frame（通常是组件渲染位置）
+    const frame = relevantFrames[0];
+    if (!frame) return null;
+
+    const mapUrl = inferSourceMapUrl(frame.fileName);
+
+    if (!mapUrl) {
+      // 没有 source map，直接返回编译后的位置
+      return {
+        fileName: frame.fileName,
+        lineNumber: frame.lineNumber,
+        columnNumber: frame.columnNumber,
+      };
+    }
+
+    // 加载并解析 source map
+    const consumer = await loadSourceMap(mapUrl);
+    if (!consumer) {
+      return {
+        fileName: frame.fileName,
+        lineNumber: frame.lineNumber,
+        columnNumber: frame.columnNumber,
+      };
+    }
+
+    const original = consumer.originalPositionFor({
+      line: frame.lineNumber,
+      column: frame.columnNumber,
+    });
+
+    if (original.source && original.line) {
+      return {
+        fileName: original.source,
+        lineNumber: original.line,
+        columnNumber: original.column ?? undefined,
+      };
+    }
+
+    return {
+      fileName: frame.fileName,
+      lineNumber: frame.lineNumber,
+      columnNumber: frame.columnNumber,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 将 file:// URL 转换为本地路径
+ * file:///Users/foo/bar.ts -> /Users/foo/bar.ts
+ * file:///C:/foo/bar.ts -> C:/foo/bar.ts (Windows)
+ */
+function fileUrlToPath(fileUrl: string): string {
+  if (!fileUrl.startsWith('file://')) {
+    return fileUrl;
+  }
+
+  // 移除 file:// 前缀
+  let path = fileUrl.slice(7);
+
+  // URL 解码（处理 %40 -> @ 等）
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    // 解码失败则保持原样
+  }
+
+  // Windows 路径处理：file:///C:/foo -> C:/foo
+  if (path.match(/^\/[A-Za-z]:\//)) {
+    path = path.slice(1);
+  }
+
+  return path;
+}
+
+/**
+ * 从指定的编译后位置反查原始位置
+ */
+export async function resolveOriginalPosition(
+  compiledUrl: string,
+  line: number,
+  column: number
+): Promise<Source | null> {
+  const mapUrl = inferSourceMapUrl(compiledUrl);
+  if (!mapUrl) {
+    return { fileName: compiledUrl, lineNumber: line, columnNumber: column };
+  }
+
+  const consumer = await loadSourceMap(mapUrl);
+  if (!consumer) {
+    return { fileName: compiledUrl, lineNumber: line, columnNumber: column };
+  }
+
+  const original = consumer.originalPositionFor({ line, column });
+
+  if (original.source && original.line) {
+    // 转换 file:// URL 为本地路径
+    const fileName = fileUrlToPath(original.source);
+    return {
+      fileName,
+      lineNumber: original.line,
+      columnNumber: original.column ?? undefined,
+    };
+  }
+
+  return { fileName: compiledUrl, lineNumber: line, columnNumber: column };
+}
+
+/**
+ * 预加载页面上所有 chunk 的 source map（可选优化）
+ */
+export async function preloadSourceMaps(): Promise<void> {
+  // 查找页面上所有的 script 标签
+  const scripts = document.querySelectorAll('script[src*=".js"]');
+  const loadPromises: Promise<void>[] = [];
+
+  scripts.forEach((script) => {
+    const src = script.getAttribute("src");
+    if (src && src.includes("/_next/")) {
+      const mapUrl = `${src}.map`;
+      loadPromises.push(
+        loadSourceMap(mapUrl).then(() => {
+          /* ignore result */
+        })
+      );
+    }
+  });
+
+  await Promise.all(loadPromises);
+}
+
+/**
+ * 清除 source map 缓存
+ */
+export function clearSourceMapCache(): void {
+  sourceMapCache.clear();
+  loadingPromises.clear();
+}

--- a/packages/runtime/src/components/Options.tsx
+++ b/packages/runtime/src/components/Options.tsx
@@ -44,12 +44,16 @@ export function Options(props: {
 
     // Sync failed, try async
     if (element) {
-      getElementInfoAsync(element, props.adapterId).then((elInfo) => {
-        // Ensure element is still the current element
-        if (props.currentElement === element) {
-          setAsyncLinkProps(elInfo?.thisElement.link || null);
-        }
-      });
+      getElementInfoAsync(element, props.adapterId)
+        .then((elInfo) => {
+          // Ensure element is still the current element
+          if (props.currentElement === element) {
+            setAsyncLinkProps(elInfo?.thisElement.link || null);
+          }
+        })
+        .catch(() => {
+          // Async resolution failed — leave as null
+        });
     } else {
       setAsyncLinkProps(null);
     }

--- a/packages/runtime/src/components/Options.tsx
+++ b/packages/runtime/src/components/Options.tsx
@@ -20,7 +20,7 @@ export function Options(props: {
 }) {
   const options = useOptions();
 
-  // 同步获取的 linkProps
+  // Synchronously fetched linkProps
   const syncLinkProps = createMemo(() =>
     props.currentElement
       ? getElementInfo(props.currentElement, props.adapterId)?.thisElement
@@ -28,24 +28,24 @@ export function Options(props: {
       : null
   );
 
-  // 异步获取的 linkProps（用于 Turbopack jsxDEV source）
+  // Async fetched linkProps (for Turbopack jsxDEV source)
   const [asyncLinkProps, setAsyncLinkProps] = createSignal<LinkProps | null>(null);
 
-  // 当 currentElement 改变且同步方式无法获取时，尝试异步获取
+  // When currentElement changes and sync fails, try async
   createEffect(() => {
     const element = props.currentElement;
     const syncResult = syncLinkProps();
 
-    // 如果同步已获取到，直接使用同步结果
+    // If sync succeeded, use sync result directly
     if (syncResult) {
       setAsyncLinkProps(null);
       return;
     }
 
-    // 同步获取失败，尝试异步获取
+    // Sync failed, try async
     if (element) {
       getElementInfoAsync(element, props.adapterId).then((elInfo) => {
-        // 确保 element 仍是当前元素
+        // Ensure element is still the current element
         if (props.currentElement === element) {
           setAsyncLinkProps(elInfo?.thisElement.link || null);
         }
@@ -55,20 +55,20 @@ export function Options(props: {
     }
   });
 
-  // 优先使用同步结果，否则使用异步结果
+  // Prefer sync result, fallback to async result
   const elLinkProps = () => syncLinkProps() || asyncLinkProps();
 
-  // debug 模式状态
+  // Debug mode state
   const [debugEnabled, setDebugEnabled] = createSignal(
     options.getOptions().debugMode ?? false
   );
 
-  // 初始化时同步 debug 状态
+  // Sync debug state on init
   createEffect(() => {
     setDebugMode(debugEnabled());
   });
 
-  // 切换 debug 模式
+  // Toggle debug mode
   const toggleDebugMode = () => {
     const newValue = !debugEnabled();
     setDebugEnabled(newValue);
@@ -115,7 +115,7 @@ export function Options(props: {
             <span>Debug Mode</span>
           </label>
           <span class="text-[10px] text-slate-400">
-            {debugEnabled() ? "(控制台查看定位日志)" : ""}
+            {debugEnabled() ? "(view location logs in console)" : ""}
           </span>
         </div>
 

--- a/packages/runtime/src/components/Options.tsx
+++ b/packages/runtime/src/components/Options.tsx
@@ -1,5 +1,5 @@
 import { cleanOptions, Targets } from "@locator/shared";
-import { createMemo } from "solid-js";
+import { createMemo, createSignal, createEffect } from "solid-js";
 import { bannerClasses } from "../functions/bannerClasses";
 import { isExtension } from "../functions/isExtension";
 import LogoIcon from "./LogoIcon";
@@ -7,7 +7,9 @@ import { OptionsCloseButton } from "./OptionsCloseButton";
 import { useOptions } from "../functions/optionsStore";
 import { AdapterId } from "../consts";
 import { LinkOptions } from "./LinkOptions";
-import { getElementInfo } from "../adapters/getElementInfo";
+import { getElementInfo, getElementInfoAsync } from "../adapters/getElementInfo";
+import { LinkProps } from "../types/types";
+import { setDebugMode } from "../adapters/react/debug";
 
 export function Options(props: {
   targets: Targets;
@@ -18,12 +20,60 @@ export function Options(props: {
 }) {
   const options = useOptions();
 
-  const elLinkProps = createMemo(() =>
+  // 同步获取的 linkProps
+  const syncLinkProps = createMemo(() =>
     props.currentElement
       ? getElementInfo(props.currentElement, props.adapterId)?.thisElement
           .link || null
       : null
   );
+
+  // 异步获取的 linkProps（用于 Turbopack jsxDEV source）
+  const [asyncLinkProps, setAsyncLinkProps] = createSignal<LinkProps | null>(null);
+
+  // 当 currentElement 改变且同步方式无法获取时，尝试异步获取
+  createEffect(() => {
+    const element = props.currentElement;
+    const syncResult = syncLinkProps();
+
+    // 如果同步已获取到，直接使用同步结果
+    if (syncResult) {
+      setAsyncLinkProps(null);
+      return;
+    }
+
+    // 同步获取失败，尝试异步获取
+    if (element) {
+      getElementInfoAsync(element, props.adapterId).then((elInfo) => {
+        // 确保 element 仍是当前元素
+        if (props.currentElement === element) {
+          setAsyncLinkProps(elInfo?.thisElement.link || null);
+        }
+      });
+    } else {
+      setAsyncLinkProps(null);
+    }
+  });
+
+  // 优先使用同步结果，否则使用异步结果
+  const elLinkProps = () => syncLinkProps() || asyncLinkProps();
+
+  // debug 模式状态
+  const [debugEnabled, setDebugEnabled] = createSignal(
+    options.getOptions().debugMode ?? false
+  );
+
+  // 初始化时同步 debug 状态
+  createEffect(() => {
+    setDebugMode(debugEnabled());
+  });
+
+  // 切换 debug 模式
+  const toggleDebugMode = () => {
+    const newValue = !debugEnabled();
+    setDebugEnabled(newValue);
+    options.setOptions({ debugMode: newValue });
+  };
 
   return (
     <div class={bannerClasses() + " w-[560px] max-w-full overflow-hidden"}>
@@ -39,11 +89,33 @@ export function Options(props: {
           targets={props.targets}
         />
 
-        <div class="flex gap-2 justify-between mt-4">
+        <div class="flex items-center gap-2 mt-4 mb-2">
+          <label class="flex items-center gap-2 cursor-pointer text-xs text-slate-600">
+            <div
+              class={`relative w-9 h-5 rounded-full transition-colors ${
+                debugEnabled() ? "bg-blue-500" : "bg-slate-300"
+              }`}
+              onClick={toggleDebugMode}
+            >
+              <div
+                class={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                  debugEnabled() ? "translate-x-4 left-0.5" : "left-0.5"
+                }`}
+              />
+            </div>
+            <span>Debug Mode</span>
+          </label>
+          <span class="text-[10px] text-slate-400">
+            {debugEnabled() ? "(控制台查看定位日志)" : ""}
+          </span>
+        </div>
+
+        <div class="flex gap-2 justify-between mt-2">
           <button
             class="bg-slate-100 py-1 px-2 rounded hover:bg-slate-300 active:bg-slate-200 cursor-pointer text-xs"
             onClick={() => {
               cleanOptions();
+              setDebugEnabled(false);
               props.onClose();
             }}
           >

--- a/packages/runtime/src/components/Runtime.tsx
+++ b/packages/runtime/src/components/Runtime.tsx
@@ -177,14 +177,32 @@ function Runtime(props: RuntimeProps) {
         return;
       }
 
-      // 先阻止默认行为，避免异步期间页面跳转
+      // Try sync resolution first
+      let elInfo = getElementInfo(target, props.adapterId);
+
+      if (elInfo?.thisElement.link) {
+        // Sync found a link — prevent default and navigate
+        e.preventDefault();
+        e.stopPropagation();
+        trackClickStats();
+
+        if (
+          (!isExtension() || detectSvelte()) &&
+          !options.getOptions().welcomeScreenDismissed
+        ) {
+          setDialog(["choose-editor", elInfo.thisElement.link]);
+        } else {
+          goToLinkProps(elInfo.thisElement.link, props.targets, options);
+        }
+        return;
+      }
+
+      // Sync failed to find link — prevent default before async to avoid
+      // page navigation during the await
       e.preventDefault();
       e.stopPropagation();
 
-      // 先尝试同步获取
-      let elInfo = getElementInfo(target, props.adapterId);
-
-      // 如果同步方式无法获取 link，尝试异步方式（source-map）
+      // Try async resolution (source-map, Turbopack, etc.)
       if (!elInfo?.thisElement.link) {
         elInfo = await getElementInfoAsync(target, props.adapterId);
       }

--- a/packages/runtime/src/components/Runtime.tsx
+++ b/packages/runtime/src/components/Runtime.tsx
@@ -21,7 +21,7 @@ import { NoLinkDialog } from "./NoLinkDialog";
 import { WelcomeScreen } from "./WelcomeScreen";
 import { isLocatorsOwnElement } from "../functions/isLocatorsOwnElement";
 import { goToLinkProps } from "../functions/goTo";
-import { getElementInfo } from "../adapters/getElementInfo";
+import { getElementInfo, getElementInfoAsync } from "../adapters/getElementInfo";
 import { getTree } from "../adapters/getTree";
 import { TreeNode } from "../types/TreeNode";
 import { TreeState } from "../adapters/adapterApi";
@@ -162,7 +162,7 @@ function Runtime(props: RuntimeProps) {
     }
   }
 
-  function clickListener(e: MouseEvent) {
+  async function clickListener(e: MouseEvent) {
     if (!isCombinationModifiersPressed(e) && uiMode()[0] !== "options") {
       return;
     }
@@ -177,13 +177,21 @@ function Runtime(props: RuntimeProps) {
         return;
       }
 
-      const elInfo = getElementInfo(target, props.adapterId);
+      // 先阻止默认行为，避免异步期间页面跳转
+      e.preventDefault();
+      e.stopPropagation();
+
+      // 先尝试同步获取
+      let elInfo = getElementInfo(target, props.adapterId);
+
+      // 如果同步方式无法获取 link，尝试异步方式（source-map）
+      if (!elInfo?.thisElement.link) {
+        elInfo = await getElementInfoAsync(target, props.adapterId);
+      }
 
       if (elInfo) {
         const linkProps = elInfo.thisElement.link;
         if (linkProps) {
-          e.preventDefault();
-          e.stopPropagation();
           trackClickStats();
 
           if (
@@ -192,10 +200,10 @@ function Runtime(props: RuntimeProps) {
           ) {
             setDialog(["choose-editor", linkProps]);
           } else {
-            // const link = buidLink(linkProps, props.targets);
             goToLinkProps(linkProps, props.targets, options);
           }
         } else {
+          // eslint-disable-next-line no-console
           console.error(
             "[LocatorJS]: Could not find link: Element info: ",
             elInfo
@@ -203,6 +211,7 @@ function Runtime(props: RuntimeProps) {
           setDialog(["no-link"]);
         }
       } else {
+        // eslint-disable-next-line no-console
         console.error(
           "[LocatorJS]: Could not find element info. Element: ",
           target
@@ -232,7 +241,7 @@ function Runtime(props: RuntimeProps) {
     });
     root.addEventListener("keydown", keyDownListener as EventListener);
     root.addEventListener("keyup", keyUpListener as EventListener);
-    root.addEventListener("click", clickListener as EventListener, {
+    root.addEventListener("click", clickListener as unknown as EventListener, {
       capture: true,
     });
     root.addEventListener("contextmenu", rightClickListener as EventListener, {
@@ -259,7 +268,7 @@ function Runtime(props: RuntimeProps) {
           capture: true,
         }
       );
-      root.removeEventListener("click", clickListener as EventListener, {
+      root.removeEventListener("click", clickListener as unknown as EventListener, {
         capture: true,
       });
       root.removeEventListener(

--- a/packages/runtime/src/functions/buildLink.test.ts
+++ b/packages/runtime/src/functions/buildLink.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test, beforeEach } from "vitest";
+import { buildLink, setInternalProjectPath } from "./buildLink";
+import type { OptionsStore } from "./optionsStore";
+
+// Minimal mock for OptionsStore
+function createMockOptions(overrides: Record<string, unknown> = {}): OptionsStore {
+  return {
+    getOptions: () => ({
+      projectPath: "/project",
+      templateOrTemplateId: undefined,
+      ...overrides,
+    }),
+  } as unknown as OptionsStore;
+}
+
+// Simple targets with a known template
+const targets = {
+  vscode: {
+    url: "vscode://file/${filePath}:${line}:${column}",
+    label: "VSCode",
+  },
+} as any;
+
+describe("buildLink - Turbopack [project]/ prefix", () => {
+  beforeEach(() => {
+    setInternalProjectPath(null as any);
+  });
+
+  test("resolves [project]/ prefix with projectPath", () => {
+    const options = createMockOptions({
+      projectPath: "/Users/me/app",
+      templateOrTemplateId: "vscode",
+    });
+
+    const result = buildLink(
+      {
+        filePath: "[project]/src/page.tsx",
+        projectPath: "",
+        line: 10,
+        column: 5,
+      },
+      targets,
+      options
+    );
+
+    expect(result).toContain("/Users/me/app/src/page.tsx");
+  });
+
+  test("handles projectPath with trailing slash", () => {
+    const options = createMockOptions({
+      projectPath: "/Users/me/app/",
+      templateOrTemplateId: "vscode",
+    });
+
+    const result = buildLink(
+      {
+        filePath: "[project]/src/page.tsx",
+        projectPath: "",
+        line: 10,
+        column: 5,
+      },
+      targets,
+      options
+    );
+
+    // Should not produce double slash
+    expect(result).toContain("/Users/me/app/src/page.tsx");
+    expect(result).not.toContain("app//src");
+  });
+
+  test("passes through paths without [project]/ prefix", () => {
+    const options = createMockOptions({
+      projectPath: "/Users/me/app",
+      templateOrTemplateId: "vscode",
+    });
+
+    const result = buildLink(
+      {
+        filePath: "/absolute/path/src/page.tsx",
+        projectPath: "",
+        line: 10,
+        column: 5,
+      },
+      targets,
+      options
+    );
+
+    expect(result).toContain("/absolute/path/src/page.tsx");
+  });
+
+  test("leaves [project]/ prefix if no projectPath available", () => {
+    const options = createMockOptions({
+      projectPath: undefined,
+      templateOrTemplateId: "vscode",
+    });
+
+    const result = buildLink(
+      {
+        filePath: "[project]/src/page.tsx",
+        projectPath: "",
+        line: 10,
+        column: 5,
+      },
+      targets,
+      options
+    );
+
+    // Without projectPath, [project]/ is kept as-is
+    expect(result).toContain("[project]/src/page.tsx");
+  });
+});

--- a/packages/runtime/src/functions/buildLink.ts
+++ b/packages/runtime/src/functions/buildLink.ts
@@ -20,9 +20,22 @@ export function buildLink(
   options: OptionsStore,
   localLinkTypeOrTemplate?: string
 ): string {
+  const savedProjectPath = getSavedProjectPath(options) || linkProps.projectPath;
+
+  // 处理 Turbopack 的 [project]/ 前缀
+  // 如果 filePath 以 [project]/ 开头，用 projectPath 替换
+  let resolvedFilePath = linkProps.filePath;
+  if (resolvedFilePath.startsWith("[project]/") && savedProjectPath) {
+    // 移除 [project]/ 前缀，拼接 projectPath
+    const relativePath = resolvedFilePath.slice("[project]/".length);
+    resolvedFilePath = savedProjectPath.endsWith("/")
+      ? savedProjectPath + relativePath
+      : savedProjectPath + "/" + relativePath;
+  }
+
   const params = {
-    filePath: linkProps.filePath,
-    projectPath: getSavedProjectPath(options) || linkProps.projectPath,
+    filePath: resolvedFilePath,
+    projectPath: savedProjectPath,
     line: String(linkProps.line),
     column: String(linkProps.column),
     linePlusOne: String(linkProps.line + 1),

--- a/packages/runtime/src/functions/getReferenceId.tsx
+++ b/packages/runtime/src/functions/getReferenceId.tsx
@@ -2,6 +2,12 @@ const map = new WeakMap();
 let lastId = 0;
 
 export function getReferenceId(ref: object): number {
+  // 验证 ref 是有效对象，避免 WeakMap 键无效错误
+  if (typeof ref !== 'object' || ref === null) {
+    lastId++;
+    return lastId;
+  }
+  
   if (!map.has(ref)) {
     lastId++;
     map.set(ref, lastId);

--- a/packages/runtime/src/functions/getReferenceId.tsx
+++ b/packages/runtime/src/functions/getReferenceId.tsx
@@ -2,7 +2,7 @@ const map = new WeakMap();
 let lastId = 0;
 
 export function getReferenceId(ref: object): number {
-  // 验证 ref 是有效对象，避免 WeakMap 键无效错误
+  // Validate ref is a valid object to avoid invalid WeakMap key errors
   if (typeof ref !== 'object' || ref === null) {
     lastId++;
     return lastId;

--- a/packages/runtime/src/functions/optionsStore.tsx
+++ b/packages/runtime/src/functions/optionsStore.tsx
@@ -5,6 +5,7 @@ import {
   ProjectOptions,
   setStoredOptions,
 } from "@locator/shared";
+import { setDebugMode } from "../adapters/react/debug";
 
 export type OptionsStore = {
   setOptions: (options: ProjectOptions) => void;
@@ -12,11 +13,19 @@ export type OptionsStore = {
 };
 
 export function initOptions(): OptionsStore {
-  const [signalOptions, setSignalOptions] = createSignal(getStoredOptions());
+  const initialOptions = getStoredOptions();
+  const [signalOptions, setSignalOptions] = createSignal(initialOptions);
+
+  // 初始化时同步 debug 状态
+  if (initialOptions.debugMode) {
+    setDebugMode(true);
+  }
 
   // This listens on localStorage changes, but the changes go only from scripts other than the current one and current one's content scripts
   listenOnOptionsChanges((newOptions) => {
     setSignalOptions(newOptions);
+    // 同步 debug 状态
+    setDebugMode(newOptions.debugMode ?? false);
   });
 
   // This listens only on changes from the contents script for this current page
@@ -32,7 +41,10 @@ export function initOptions(): OptionsStore {
         event.data.type &&
         event.data.type == "LOCATOR_EXTENSION_UPDATED_OPTIONS"
       ) {
-        setSignalOptions(getStoredOptions());
+        const newOptions = getStoredOptions();
+        setSignalOptions(newOptions);
+        // 同步 debug 状态
+        setDebugMode(newOptions.debugMode ?? false);
       }
     },
     false

--- a/packages/runtime/src/functions/optionsStore.tsx
+++ b/packages/runtime/src/functions/optionsStore.tsx
@@ -16,7 +16,7 @@ export function initOptions(): OptionsStore {
   const initialOptions = getStoredOptions();
   const [signalOptions, setSignalOptions] = createSignal(initialOptions);
 
-  // 初始化时同步 debug 状态
+  // Sync debug state on initialization
   if (initialOptions.debugMode) {
     setDebugMode(true);
   }
@@ -24,7 +24,7 @@ export function initOptions(): OptionsStore {
   // This listens on localStorage changes, but the changes go only from scripts other than the current one and current one's content scripts
   listenOnOptionsChanges((newOptions) => {
     setSignalOptions(newOptions);
-    // 同步 debug 状态
+    // Sync debug state
     setDebugMode(newOptions.debugMode ?? false);
   });
 
@@ -43,7 +43,7 @@ export function initOptions(): OptionsStore {
       ) {
         const newOptions = getStoredOptions();
         setSignalOptions(newOptions);
-        // 同步 debug 状态
+        // Sync debug state
         setDebugMode(newOptions.debugMode ?? false);
       }
     },

--- a/packages/shared/src/sharedOptionsStore.ts
+++ b/packages/shared/src/sharedOptionsStore.ts
@@ -10,6 +10,7 @@ export type ProjectOptions = {
   showIntro?: boolean;
   welcomeScreenDismissed?: boolean;
   hrefTarget?: "_blank" | "_self";
+  debugMode?: boolean;
 };
 
 let reported = false;
@@ -70,6 +71,9 @@ export function getStoredOptions(): ProjectOptions {
     }
     if (typeof parsedOptions.welcomeScreenDismissed === "boolean") {
       options.welcomeScreenDismissed = parsedOptions.welcomeScreenDismissed;
+    }
+    if (typeof parsedOptions.debugMode === "boolean") {
+      options.debugMode = parsedOptions.debugMode;
     }
   }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -201,7 +201,7 @@ export type ReactInternals = {
   currentDispatcherRef: any;
   getCurrentFiber: () => Fiber | null;
   rendererPackageName?: string;
-  // React 19 移除了此 API，改为可选
+  // React 19 removed this API, now optional
   findFiberByHostInstance?: (hostInstance: NativeType) => Fiber | null;
 };
 
@@ -667,23 +667,23 @@ export type RecordEventHandler = (
 
 /**
  * React DevTools 7.0.1+ RendererInterface API
- * 每个 renderer 暴露的接口，用于获取组件信息和源码位置
+ * Interface exposed by each renderer for getting component info and source locations
  */
 export type RendererInterface = {
-  // 从 DOM 元素获取 React 内部元素 ID
+  // Get React internal element ID from a DOM element
   getElementIDForHostInstance: (hostInstance: NativeType) => number | null;
-  // 通过 ID 获取组件的源函数/类
+  // Get component's source function/class by ID
   getElementSourceFunctionById?: (id: number) => ((...args: any[]) => any) | null;
-  // 检查元素，返回包含 source 等详细信息
+  // Inspect element, returns detailed info including source
   inspectElement: (
     requestID: number,
     id: number,
     path: Array<string | number> | null,
     forceFullData?: boolean
   ) => InspectElementResult | null;
-  // 获取元素在树中的路径
+  // Get the element's path in the tree
   getPathForElement?: (id: number) => Array<PathFrame> | null;
-  // 查找 Fiber（部分版本可用）
+  // Find Fiber (available in some versions)
   findFiberByHostInstance?: (hostInstance: NativeType) => Fiber | null;
 };
 
@@ -702,15 +702,9 @@ export type ReactDevtoolsHook = {
     priorityLevel: any
   ) => void;
   onPostCommitFiberRoot: (rendererId: number, root: FiberRoot) => void;
-  // 传统 renderers Map
+  // Legacy renderers Map
   renderers?: Map<number, ReactInternals>;
-  // React DevTools 7.0.1+ 新增的 rendererInterfaces
+  // rendererInterfaces added in React DevTools 7.0.1+
   rendererInterfaces?: Map<number, RendererInterface>;
 };
 
-// 扩展全局 Window 类型
-declare global {
-  interface Window {
-    __REACT_DEVTOOLS_GLOBAL_HOOK__?: ReactDevtoolsHook;
-  }
-}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,26 +1,6 @@
 export type FiberType = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 export type FiberRootMode = 0 | 1 | 2;
 
-export type ReactDevtoolsHook = {
-  supportsFiber: boolean;
-  inject: (renderer: ReactInternals) => number;
-  // onScheduleRoot(rendererId: number, root: FiberRoot, children: any[]) {},
-  onCommitFiberUnmount: (rendererId: number, fiber: Fiber) => void;
-  onCommitFiberRoot: (
-    rendererId: number,
-    root: FiberRoot,
-    priorityLevel: any
-  ) => void;
-  onPostCommitFiberRoot: (rendererId: number, root: FiberRoot) => void;
-
-  // Not used. It is declared to follow React Devtools hook's behaviour
-  // in order for other tools like react-render to work
-  renderers?: Map<number, ReactInternals>;
-
-  // Marker is here but we can ignore it
-  // [MARKER]?: typeof MARKER;
-};
-
 export type Renderer = ReactInternals;
 
 export type TransferFiber = {
@@ -221,7 +201,8 @@ export type ReactInternals = {
   currentDispatcherRef: any;
   getCurrentFiber: () => Fiber | null;
   rendererPackageName?: string;
-  findFiberByHostInstance: (hostInstance: NativeType) => Fiber | null;
+  // React 19 移除了此 API，改为可选
+  findFiberByHostInstance?: (hostInstance: NativeType) => Fiber | null;
 };
 
 // TODO maybe add HTMLElement to this type
@@ -683,3 +664,53 @@ export type ReactIntegration = ReactDevtoolsHookHandlers & ReactInterationApi;
 export type RecordEventHandler = (
   payload: DistributiveOmit<Message, "id">
 ) => number;
+
+/**
+ * React DevTools 7.0.1+ RendererInterface API
+ * 每个 renderer 暴露的接口，用于获取组件信息和源码位置
+ */
+export type RendererInterface = {
+  // 从 DOM 元素获取 React 内部元素 ID
+  getElementIDForHostInstance: (hostInstance: NativeType) => number | null;
+  // 通过 ID 获取组件的源函数/类
+  getElementSourceFunctionById?: (id: number) => ((...args: any[]) => any) | null;
+  // 检查元素，返回包含 source 等详细信息
+  inspectElement: (
+    requestID: number,
+    id: number,
+    path: Array<string | number> | null,
+    forceFullData?: boolean
+  ) => InspectElementResult | null;
+  // 获取元素在树中的路径
+  getPathForElement?: (id: number) => Array<PathFrame> | null;
+  // 查找 Fiber（部分版本可用）
+  findFiberByHostInstance?: (hostInstance: NativeType) => Fiber | null;
+};
+
+export type InspectElementResult = {
+  type: 'full-data' | 'hydrated-path' | 'no-change' | 'not-found';
+  value?: InspectedElement;
+};
+
+export type ReactDevtoolsHook = {
+  supportsFiber: boolean;
+  inject: (renderer: ReactInternals) => number;
+  onCommitFiberUnmount: (rendererId: number, fiber: Fiber) => void;
+  onCommitFiberRoot: (
+    rendererId: number,
+    root: FiberRoot,
+    priorityLevel: any
+  ) => void;
+  onPostCommitFiberRoot: (rendererId: number, root: FiberRoot) => void;
+  // 传统 renderers Map
+  renderers?: Map<number, ReactInternals>;
+  // React DevTools 7.0.1+ 新增的 rendererInterfaces
+  rendererInterfaces?: Map<number, RendererInterface>;
+};
+
+// 扩展全局 Window 类型
+declare global {
+  interface Window {
+    __REACT_DEVTOOLS_GLOBAL_HOOK__?: ReactDevtoolsHook;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,34 @@ importers:
         specifier: ^5
         version: 5.2.2
 
+  apps/next-16-turbopack:
+    dependencies:
+      next:
+        specifier: 16.0.0
+        version: 16.0.0(@babel/core@7.28.5)(react-dom@19.2.0)(react@19.2.0)
+      react:
+        specifier: 19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@locator/runtime':
+        specifier: workspace:^
+        version: link:../../packages/runtime
+      '@types/node':
+        specifier: ^20
+        version: 20.4.2
+      '@types/react':
+        specifier: ^19
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.2(@types/react@19.2.2)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   apps/playwright:
     devDependencies:
       '@playwright/test':
@@ -18205,6 +18233,7 @@ packages:
   /next@16.0.0(@babel/core@7.28.5)(react-dom@19.2.0)(react@19.2.0):
     resolution: {integrity: sha512-nYohiNdxGu4OmBzggxy9rczmjIGI+TpR5vbKTsE1HqYwNm1B+YSiugSrFguX6omMOKnDHAmBPY4+8TNJk0Idyg==}
     engines: {node: '>=20.9.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0


### PR DESCRIPTION
## Summary

Merged and reworked PR #199 from Feahter's fork adding React 19/Next.js 15+/Turbopack source resolution support. Major cleanup: translated all Chinese strings to English, fixed unconditional preventDefault, resolved type conflicts, and added comprehensive test coverage for new resolution strategies.

## Changes

- **Translation**: All Chinese comments/strings (100+) across 14+ files translated to English for consistency
- **React 19 Support**: Added async source resolution methods (rendererInterfaces API, _debugInfo, _debugStack, Turbopack chunk parsing, source-map reverse lookup)
- **Bug Fix**: Fixed unconditional preventDefault/stopPropagation in clickListener with two-phase approach
- **Build Fix**: Fixed react-devtools-hook build by adding `noEmit: false` to tsconfig
- **Type Fix**: Removed duplicate ReactDevtoolsHook global declaration
- **Tests**: Added 33 new tests covering VLQ decoding, mappings parsing, fileUrlToPath, buildLink Turbopack resolution, and debug mode
- **Exports**: Exposed internal functions for testing (decodeVLQ, parseMappings, fileUrlToPath, MappingSegment)

## Verification

✅ All 44 tests pass (33 new + 11 existing)
✅ All packages build clean (shared, runtime, react-devtools-hook, extension)
✅ Zero Chinese characters remaining in codebase

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core element-to-source resolution and click-to-navigate flow (now async with multiple fallbacks), which could affect navigation reliability and performance in dev environments; changes are localized to dev tooling/runtime behavior with added tests and debug instrumentation.
> 
> **Overview**
> Improves LocatorJS navigation for **React 19 / Next.js (Turbopack)** by adding an async fallback path when sync Fiber source metadata is missing, including a new React click resolver that can use DevTools `rendererInterfaces`, `_debugInfo`/`_debugStack`, source-map reverse lookup, and Turbopack chunk `jsxDEV` parsing.
> 
> Adds **Debug Mode** (UI toggle + `window.__LOCATORJS_DEBUG__`) with console tracing/history and a `window.locatorDiagnose()` helper; wires debug state through persisted options, and updates the runtime click handler to only `preventDefault` immediately when a link is found (or before awaiting async resolution).
> 
> Also updates link building to resolve Turbopack `[project]/` paths, hardens WeakMap ID helpers against non-object keys, adjusts shared React DevTools types for React 19, adds a new `apps/next-16-turbopack` repro app, expands tests around source-map parsing/debug/link building, and refreshes extension docs/scripts with a new node-based release packager.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82f29d2c3afb9dd097128d7902cdde5e7bb97982. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->