### PR TITLE
Fix: route Antigravity editor link to v1 (antigravity-ide://) after v2 release

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -29,8 +29,8 @@ export const allTargets: Targets = {
     label: "Windsurf",
   },
   antigravity: {
-    url: "antigravity://file/${projectPath}${filePath}:${line}:${column}",
-    label: "Antigravity",
+    url: "antigravity-ide://file/${projectPath}${filePath}:${line}:${column}",
+    label: "Antigravity IDE",
   },
   nvim: {
     url: "nvim://file/${projectPath}${filePath}:${line}:${column}",


### PR DESCRIPTION
## Problem

  After Google released **Antigravity v2** (an agent-first platform), the existing LocatorJS
  "Antigravity" editor link stopped working as expected — clicking a component now opens v2 instead of
  v1 (the IDE). v2 is not a code editor, so files don't open.

  ## Root cause

  Antigravity v1 and v2 are separate apps registering different URL schemes on macOS:

  | App | Bundle ID | URL scheme |
  | --- | --- | --- |
  | `Antigravity IDE.app` (v1) | `com.google.antigravity-ide` | `antigravity-ide://` |
  | `Antigravity.app` (v2) | `com.google.antigravity` | `antigravity://` |

  LocatorJS was using `antigravity://`, which is now handled by v2.

  ## Fix

  Change the editor link in `packages/shared/src/index.ts` from `antigravity://` to
  `antigravity-ide://`:

  ```diff
   antigravity: {
  -  url: "antigravity://file/${projectPath}${filePath}:${line}:${column}",
  -  label: "Antigravity",
  +  url: "antigravity-ide://file/${projectPath}${filePath}:${line}:${column}",
  +  label: "Antigravity IDE",
   },
  ```

  ## Verification
  1. `pnpm build`
  2. Load `apps/extension/build/production_chrome` as unpacked in `chrome://extensions/`
  3. Click a component → v1 (Antigravity IDE) opens.