### PR TITLE
Fix local Playwright: upgrade to 1.62.1, correct the install rough edge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,11 +130,19 @@ so it is **not** run by `pnpm e2e` and does not run in CI.
 
 Things that will waste your time if you rediscover them:
 
-- **Playwright browsers may not launch locally.** If you see
-  `Executable doesn't exist at .../chromium_headless_shell-<rev>`, the pinned
-  revision isn't installed and `--headed` may SIGABRT too. It is an environment
-  problem, not your change — CI installs browsers fresh. Confirm by stashing
-  your work and reproducing.
+- **`playwright install` needs the Node version in `.nvmrc`.** On Node 26 the
+  download finishes in seconds and then extraction deadlocks at ~1 MB with the
+  process at 0% CPU — no error, no timeout, just a hang, and killing it leaves a
+  `~/Library/Caches/ms-playwright/__dirlock` that makes every later install
+  abort with "An active lockfile is found". Playwright 1.62 fixed this; 1.59 and
+  earlier hang. If you hit it on an older branch, `rm -rf` the `__dirlock` and
+  re-run under Node 22. A partially-extracted browser dir also has to go, or
+  you get `Executable doesn't exist at .../chromium_headless_shell-<rev>` at
+  test time.
+- **`pnpm e2e` on default ports reuses another workspace's servers.**
+  `reuseExistingServer` is on locally, so if a parallel Conductor workspace has
+  `pnpm dev` up, Playwright silently tests _that_ checkout. Give the run its own
+  block first: `PORT=45000 . ./scripts/dev-ports.sh && pnpm e2e`.
 - **`--no-webstorage` in three vitest configs is load-bearing.** Node 25+ turned
   on Web Storage, which shadows jsdom's `localStorage` and breaks every test
   touching it (vitest-dev/vitest#8757). The configs probe the running Node

--- a/apps/playwright/package.json
+++ b/apps/playwright/package.json
@@ -11,7 +11,7 @@
     "ts": "tsc --noEmit"
   },
   "devDependencies": {
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^22.19.17",
     "typescript": "^5.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,8 @@ importers:
   apps/playwright:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.59.1
-        version: 1.59.1
+        specifier: ^1.62.1
+        version: 1.62.1
       '@types/node':
         specifier: ^22.19.17
         version: 22.19.17
@@ -5740,12 +5740,12 @@ packages:
     dev: true
     optional: true
 
-  /@playwright/test@1.59.1:
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
-    engines: {node: '>=18'}
+  /@playwright/test@1.62.1:
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
     hasBin: true
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.62.1
     dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.11.0)(webpack@5.106.2):
@@ -20426,18 +20426,18 @@ packages:
       pathe: 2.0.3
     dev: true
 
-  /playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
-    engines: {node: '>=18'}
+  /playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
     hasBin: true
     dev: true
 
-  /playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
-    engines: {node: '>=18'}
+  /playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
`playwright install` was hanging locally, and `AGENTS.md` blamed an unexplained missing-executable environment problem; the real cause is a Node 26 extraction deadlock in Playwright <= 1.61, where the download completes in ~5s and the process then sits at 0% CPU with ~1.5 MB unpacked, leaving a partially-extracted browser dir (the missing executable) and a `__dirlock` that blocks every later install. This upgrades `@playwright/test` from 1.59.1 to 1.62.1, which fixes it — `apps/playwright` is the only consumer, so `dependency-versions` is unaffected. It also rewrites that rough-edge bullet to record the cause, the `__dirlock` cleanup and the Node 22 fallback for older branches, and adds a second bullet for the `pnpm e2e` port-collision trap, where `reuseExistingServer` on default ports silently tests whichever parallel Conductor workspace has `pnpm dev` up.

`origin/v2` is merged in (clean, no conflicts) and `pnpm check` is green on the merged state. Local e2e on the merged tree is flaky in a way this PR does not cause and does not fix: three runs gave 164/168, 167/168 and 168/168, every failure being the `expectLocatorReady` Settings-button timeout that v2's own `retries` comment already documents, and CI's `retries: 2` masks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)