### PR TITLE
ci: replace anonymous e2e shards with named semantic groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,27 @@ jobs:
       - run: pnpm build
       - run: pnpm check
 
+  # One job per named group of specs, instead of three anonymous `--shard`
+  # thirds. Two reasons. A red check now names the area that broke — `--shard`
+  # splits individual tests, so every shard was an arbitrary mix drawn from all
+  # six spec files. And each job boots only the dev servers its specs navigate
+  # to: five of these six need one app, where every shard started all ten and
+  # spent ~48s waiting for them.
   e2e:
-    name: e2e (shard ${{ matrix.shard }})
+    name: e2e (${{ matrix.group }})
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: build
     strategy:
-      # One shard failing should not hide the results of the others.
+      # One group failing should not hide the results of the others.
       fail-fast: false
       matrix:
-        shard: ["1/3", "2/3", "3/3"]
+        # Which specs and servers each of these means lives in
+        # apps/playwright/e2e-groups.ts. A GitHub matrix has to be literal, so
+        # the names are repeated here; that file reads this list back and fails
+        # if the two disagree, because a group with no matrix entry would
+        # otherwise just stop running, green.
+        group: [basics, tree, embedding, settings, bindings, next]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
@@ -81,24 +92,52 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
       - run: pnpm build
+      # Downloading three browsers is most of this job's fixed cost, and there
+      # are six jobs paying it. Keyed on the resolved Playwright version, so a
+      # bump invalidates it and nothing else does. On the first run after a bump
+      # all six jobs miss and race to save the same key; actions/cache resolves
+      # that with a harmless "already exists" warning.
+      - name: Resolve Playwright version
+        id: playwright
+        working-directory: apps/playwright
+        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        name: Playwright browser cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+      # Still unconditional on a cache hit, rather than skipped. `install` is
+      # idempotent — it checks each browser's revision marker and downloads only
+      # what is missing — so this both repairs a cache that was saved from a
+      # half-finished download and covers the half of `--with-deps` that cannot
+      # be cached at all: the system libraries are apt packages, not files under
+      # ~/.cache/ms-playwright.
       - name: Install Playwright browsers
         working-directory: apps/playwright
         run: pnpm exec playwright install --with-deps
       # No dev-server startup or port-wait steps here on purpose: the webServer
       # array in apps/playwright/playwright.config.ts owns starting every app,
-      # waiting for it, and capturing its output. Each shard boots its own set,
-      # which is what keeps the shards isolated from each other.
+      # waiting for it, and capturing its output. E2E_GROUP decides which ones,
+      # so a job boots only what its own specs use and stays isolated from the
+      # other groups.
       #
-      # Invoked directly rather than through `pnpm e2e` so --shard can be
-      # passed; the e2e turbo task is `cache: false` anyway, so nothing is lost.
+      # Invoked directly rather than through `pnpm e2e` because that script
+      # hardcodes the whole ./tests/libs path, which would undo the group's
+      # filtering; the e2e turbo task is `cache: false` anyway, so nothing is
+      # lost.
       - name: Run Playwright tests
         working-directory: apps/playwright
-        run: pnpm exec playwright test ./tests/libs --shard=${{ matrix.shard }}
+        env:
+          E2E_GROUP: ${{ matrix.group }}
+        run: pnpm exec playwright test
       - name: Upload blob report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
-          name: blob-report-${{ strategy.job-index }}
+          # Named after the group rather than strategy.job-index so the artifact
+          # list is readable. The zip inside is report-<group>.zip for a harder
+          # reason; see the reporter comment in playwright.config.ts.
+          name: blob-report-${{ matrix.group }}
           path: apps/playwright/blob-report/
           if-no-files-found: warn
           retention-days: 7
@@ -107,7 +146,9 @@ jobs:
     name: e2e report
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Runs even when a shard fails, so there is always a merged report to read.
+    # Runs even when a group fails, so there is always a merged report to read.
+    # Note this job is not a gate: merge-reports exits 0 whatever the tests did,
+    # so it is green on a red suite. The e2e (<group>) jobs are the checks.
     if: ${{ !cancelled() }}
     needs: e2e
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         # the names are repeated here; that file reads this list back and fails
         # if the two disagree, because a group with no matrix entry would
         # otherwise just stop running, green.
-        group: [basics, tree, embedding, settings, bindings, next]
+        group: [adapters, tree, embedding, settings, bindings, next]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,26 +92,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
       - run: pnpm build
-      # Downloading three browsers is most of this job's fixed cost, and there
-      # are six jobs paying it. Keyed on the resolved Playwright version, so a
-      # bump invalidates it and nothing else does. On the first run after a bump
-      # all six jobs miss and race to save the same key; actions/cache resolves
-      # that with a harmless "already exists" warning.
-      - name: Resolve Playwright version
-        id: playwright
-        working-directory: apps/playwright
-        run: echo "version=$(pnpm exec playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        name: Playwright browser cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
-      # Still unconditional on a cache hit, rather than skipped. `install` is
-      # idempotent — it checks each browser's revision marker and downloads only
-      # what is missing — so this both repairs a cache that was saved from a
-      # half-finished download and covers the half of `--with-deps` that cannot
-      # be cached at all: the system libraries are apt packages, not files under
-      # ~/.cache/ms-playwright.
+      # ~45s per job, six times over, and not worth caching: measured, this step
+      # is apt, not download. Caching ~/.cache/ms-playwright does eliminate the
+      # browser downloads — run 32628277049 hit the cache and fetched no
+      # browsers at all — and the step still took 24-57s, because `--with-deps`
+      # installs the system libraries the browsers need and those are apt
+      # packages, outside any path a cache can hold. Restoring the 467MB entry
+      # cost 6-7s against ~15s of downloads saved, inside the noise of apt's own
+      # variance. So: no cache, one step.
       - name: Install Playwright browsers
         working-directory: apps/playwright
         run: pnpm exec playwright install --with-deps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,10 +123,12 @@ Unit tests are colocated `*.test.ts(x)` next to the source, run by **vitest**:
 E2E lives in `apps/playwright/tests/libs` (168 tests, 3 browsers), driven
 against the `test-apps/` fixtures.
 
-CI runs it as six **named groups** — `basics`, `tree`, `embedding`, `settings`,
-`bindings`, `next` — not as anonymous shards. `apps/playwright/e2e-groups.ts`
-defines which specs and which dev servers each one gets, so a job boots only
-the apps its specs navigate to. Run one locally with
+CI runs it as six **named groups** — `adapters`, `tree`, `embedding`,
+`settings`, `bindings`, `next` — not as anonymous shards.
+`apps/playwright/e2e-groups.ts` defines which specs and which dev servers each
+one gets, so a job boots only the apps its specs navigate to. `adapters` is the
+one that needs seven servers: it varies the framework rather than the depth, one
+shallow test per app over `packages/runtime/src/adapters`. Run one locally with
 `E2E_GROUP=<name> pnpm exec playwright test` from `apps/playwright`; leave the
 variable unset and you get the whole suite and all ten servers, as before.
 
@@ -187,8 +189,8 @@ Things that will waste your time if you rediscover them:
 
 - **build** → populates the turbo cache
 - **check** → `pnpm check`; all non-e2e gates in one job
-- **e2e (basics | tree | embedding | settings | bindings | next)** → Playwright,
-  each group booting only the dev servers its own specs use
+- **e2e (adapters | tree | embedding | settings | bindings | next)** →
+  Playwright, each group booting only the dev servers its own specs use
 - **e2e report** → merges the six blob reports into one HTML report. Not a gate:
   `merge-reports` exits 0 whatever the tests did, so this job is green on a red
   suite. The `e2e (<group>)` jobs are the checks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,10 +121,25 @@ Unit tests are colocated `*.test.ts(x)` next to the source, run by **vitest**:
 `tests/fixtures/`.
 
 E2E lives in `apps/playwright/tests/libs` (168 tests, 3 browsers), driven
-against the `test-apps/` fixtures. CI shards it three ways.
+against the `test-apps/` fixtures.
+
+CI runs it as six **named groups** — `basics`, `tree`, `embedding`, `settings`,
+`bindings`, `next` — not as anonymous shards. `apps/playwright/e2e-groups.ts`
+defines which specs and which dev servers each one gets, so a job boots only
+the apps its specs navigate to. Run one locally with
+`E2E_GROUP=<name> pnpm exec playwright test` from `apps/playwright`; leave the
+variable unset and you get the whole suite and all ten servers, as before.
+
+**A new spec file must be added to a group.** Otherwise CI silently stops
+running it. That is checked, not trusted: `e2e-groups.ts` throws at config load
+if a spec belongs to no group, if a group is missing an app its specs visit, or
+if the group list and `ci.yml`'s matrix disagree. Renaming a group means editing
+both, and the check will tell you so.
 
 `apps/playwright/tests/extensions` needs a real extension build and `--headed`,
-so it is **not** run by `pnpm e2e` and does not run in CI.
+so it is **not** run by `pnpm e2e` and does not run in CI. It has a group
+(`extension`, marked `ci: false`) only so `vite-svelte-clean-project` has a
+stated reason to exist.
 
 ## Known rough edges
 
@@ -159,6 +174,10 @@ Things that will waste your time if you rediscover them:
   `panda codegen` builds fine.
 - **`packages/locatorjs` is a published stub** whose `main` points at a `dist`
   nothing builds.
+- **Renaming an e2e group renames a CI check.** Required status checks are
+  typed into GitHub's branch protection by hand, so a group rename leaves PRs
+  waiting forever on a check that will never report again. Update the required
+  check names in the same change.
 - **`.context/` is gitignored** agent scratch space. Put screenshots and repro
   scripts there, not in the repo proper.
 
@@ -168,8 +187,11 @@ Things that will waste your time if you rediscover them:
 
 - **build** → populates the turbo cache
 - **check** → `pnpm check`; all non-e2e gates in one job
-- **e2e (shard 1..3/3)** → Playwright, each shard with its own dev servers
-- **e2e report** → merges the shard blob reports into one HTML report
+- **e2e (basics | tree | embedding | settings | bindings | next)** → Playwright,
+  each group booting only the dev servers its own specs use
+- **e2e report** → merges the six blob reports into one HTML report. Not a gate:
+  `merge-reports` exits 0 whatever the tests did, so this job is green on a red
+  suite. The `e2e (<group>)` jobs are the checks.
 
 Failures are annotated inline on the PR by Playwright's `github` reporter, so
 you usually don't need to download an artifact.

--- a/apps/playwright/e2e-groups.ts
+++ b/apps/playwright/e2e-groups.ts
@@ -41,7 +41,20 @@ export type Group = {
 };
 
 export const groups = {
-  basics: {
+  /**
+   * The only group that needs seven servers, because the thing it varies is the
+   * framework: one shallow test per app, each checking that the runtime mounts
+   * and resolves a component there. That is coverage of
+   * packages/runtime/src/adapters — jsx, react, svelte, vue — plus react-clean
+   * as the negative control, so it is named after them.
+   *
+   * The file is still basics.spec.ts. Its name predates the split and reads as
+   * "basic functionality", which is what this group is *not*: the tests are
+   * shallow on purpose and broad by design. Renaming it would break the tie to
+   * the commits documenting its solid flake (see `retries` in
+   * playwright.config.ts), so the group carries the accurate name instead.
+   */
+  adapters: {
     specs: ["libs/basics.spec.ts"],
     apps: ["web", "react", "preact", "solid", "svelte", "reactClean", "vue"],
   },

--- a/apps/playwright/e2e-groups.ts
+++ b/apps/playwright/e2e-groups.ts
@@ -1,0 +1,253 @@
+import * as fs from "fs";
+import * as path from "path";
+import {
+  appKeys,
+  appOrigin,
+  appServing,
+  type AppKey,
+  type PageKey,
+} from "./tests/apps";
+
+/**
+ * Which specs run together, and which dev servers that needs.
+ *
+ * This file exists so CI can say `e2e (embedding)` instead of
+ * `e2e (shard 2/3)`. A group decides two things:
+ *
+ *   - Which specs run, so a red check names the area that broke rather than an
+ *     arbitrary third of the suite. `--shard` splits individual tests, so every
+ *     shard was a mix drawn from all six spec files.
+ *   - Which dev servers boot. Five of these six need a single app, where every
+ *     shard used to start all ten and wait ~48s for the Next ones.
+ *
+ * Groups are one-per-file today, but `specs` is a list on purpose: a small new
+ * spec belongs in an existing group, not in a seventh CI job paying another
+ * ~80s of checkout, install and browser download.
+ *
+ * It lives at the package root rather than under tests/ because it is
+ * configuration, not a test helper: playwright.config.ts is the only thing that
+ * should import it, and nothing under tests/ does. Playwright re-evaluates the
+ * config in every worker process, so the checks below run a handful of times
+ * per run — they are a few small file reads, which is affordable, but keep them
+ * that way.
+ */
+export type Group = {
+  /** Spec files, relative to tests/. Used verbatim as the config's testMatch. */
+  specs: string[];
+  /** The servers these specs need, and the only ones the job will boot. */
+  apps: AppKey[];
+  /** Left out of the CI matrix. */
+  ci?: false;
+};
+
+export const groups = {
+  basics: {
+    specs: ["libs/basics.spec.ts"],
+    apps: ["web", "react", "preact", "solid", "svelte", "reactClean", "vue"],
+  },
+  tree: { specs: ["libs/tree-parents.spec.ts"], apps: ["react"] },
+  embedding: { specs: ["libs/embedding.spec.ts"], apps: ["react"] },
+  settings: { specs: ["libs/settings.spec.ts"], apps: ["solid"] },
+  bindings: { specs: ["libs/binding-actions.spec.ts"], apps: ["solid"] },
+  next: {
+    specs: ["libs/next16.spec.ts"],
+    apps: ["next16", "next16Turbopack"],
+  },
+  /**
+   * Not in CI: tests/extensions needs a real extension build and --headed. It
+   * is declared anyway so vite-svelte-clean-project has a stated reason to be
+   * in the default server list — nothing under tests/libs touches it — and so
+   * `E2E_GROUP=extension` is a thing you can run.
+   */
+  extension: {
+    specs: ["extensions/extension.spec.ts"],
+    apps: ["reactClean", "svelteClean"],
+    ci: false,
+  },
+} satisfies Record<string, Group>;
+
+export type GroupName = keyof typeof groups;
+
+const groupNames = Object.keys(groups) as GroupName[];
+
+/**
+ * `satisfies` keeps the literal type of the table above — which is what makes
+ * `GroupName` a union of the real names — at the cost of each entry being typed
+ * only as narrowly as it is written: `apps: ["react"]` is `"react"[]`, and `ci`
+ * is simply absent from the six entries that omit it. Read entries through here
+ * to get the declared shape back.
+ */
+const groupOf = (name: GroupName): Group => groups[name];
+
+/** The groups the CI matrix is expected to contain. */
+export const ciGroups = groupNames.filter((name) => groupOf(name).ci !== false);
+
+const TESTS_DIR = path.join(__dirname, "tests");
+const CI_WORKFLOW = path.join(
+  __dirname,
+  "..",
+  "..",
+  ".github",
+  "workflows",
+  "ci.yml"
+);
+
+const fail = (message: string): never => {
+  throw new Error(
+    `e2e-groups.ts: ${message}\n\nEvery spec file has to belong to exactly ` +
+      `one group, and every group needs a matrix entry in ` +
+      `.github/workflows/ci.yml — otherwise CI stops running it and stays green.`
+  );
+};
+
+/** Every *.spec.ts under tests/, as a tests/-relative posix path. */
+function specsOnDisk(): string[] {
+  return fs
+    .readdirSync(TESTS_DIR, { recursive: true, encoding: "utf8" })
+    .filter((file) => file.endsWith(".spec.ts"))
+    .map((file) => file.split(path.sep).join("/"));
+}
+
+/**
+ * The group names in ci.yml's matrix.
+ *
+ * Reading the workflow back is unusual for a Playwright config, and it is here
+ * because a GitHub matrix has to be literal — it cannot be computed from this
+ * file. The dangerous direction of drift is silent: delete a name from the
+ * matrix, or rename a group here, and those specs simply stop running, green.
+ * (The reverse — a stale name in the matrix — already fails loudly in
+ * `activeGroup`.)
+ *
+ * Understands the flow form this file writes, `group: [a, b]`, and the block
+ * form a reformat might produce. Anything else throws rather than guessing.
+ */
+function matrixGroups(): string[] {
+  const workflow = fs.readFileSync(CI_WORKFLOW, "utf8");
+
+  const flow = workflow.match(/^[ \t]*group:[ \t]*\[([\s\S]*?)\]/m);
+  if (flow) {
+    return flow[1]
+      .split(",")
+      .map((name) => name.trim())
+      .filter(Boolean);
+  }
+
+  const block = workflow.match(
+    /^[ \t]*group:[ \t]*\r?\n((?:[ \t]*-[ \t]*[\w-]+[ \t]*\r?\n)+)/m
+  );
+  if (block) {
+    return block[1]
+      .split("\n")
+      .map((line) => line.replace(/^[ \t]*-[ \t]*/, "").trim())
+      .filter(Boolean);
+  }
+
+  return fail(
+    `could not find the e2e matrix's \`group:\` list in ${path.relative(
+      __dirname,
+      CI_WORKFLOW
+    )}. If the matrix was reformatted, either restore \`group: [a, b, c]\` or ` +
+      `teach matrixGroups() the new shape`
+  );
+}
+
+/**
+ * The cost of naming the jobs is that this mapping can rot, and every way it
+ * rots is silent. So it is checked on every config load — in each CI job and in
+ * a plain `pnpm e2e` — and throws before a single dev server starts.
+ */
+function assertGroupsAreComplete(): void {
+  const owner = new Map<string, GroupName>();
+
+  for (const name of groupNames) {
+    // A group name becomes a job name, an artifact name and a blob file name.
+    if (!/^[a-z0-9-]+$/.test(name)) {
+      fail(`group "${name}" is not a safe slug ([a-z0-9-]+)`);
+    }
+    for (const spec of groupOf(name).specs) {
+      if (!fs.existsSync(path.join(TESTS_DIR, spec))) {
+        fail(`group "${name}" lists tests/${spec}, which does not exist`);
+      }
+      const other = owner.get(spec);
+      if (other) fail(`tests/${spec} is in both "${other}" and "${name}"`);
+      owner.set(spec, name);
+    }
+  }
+
+  const orphans = specsOnDisk().filter((spec) => !owner.has(spec));
+  if (orphans.length) {
+    fail(
+      `no group runs ${orphans.map((spec) => `tests/${spec}`).join(", ")}. ` +
+        `Add each to a group's \`specs\``
+    );
+  }
+
+  /**
+   * Which app each spec needs, read off its own source. Only direct
+   * `projects.<key>` references are visible here, which is every reference
+   * today; an indirect one (`projects[name]`, or a helper in a third file)
+   * would slip through and surface as a bare ERR_CONNECTION_REFUSED on a port
+   * number, so keep them direct.
+   */
+  for (const [spec, name] of owner) {
+    const source = fs.readFileSync(path.join(TESTS_DIR, spec), "utf8");
+    const needed = new Set<AppKey>();
+    for (const [, key] of source.matchAll(/\bprojects\.(\w+)/g)) {
+      needed.add(appServing(key as PageKey));
+    }
+    for (const app of needed) {
+      if (!groupOf(name).apps.includes(app)) {
+        fail(
+          `tests/${spec} navigates to the "${app}" app, but group "${name}" ` +
+            `does not boot it — add "${app}" to its \`apps\``
+        );
+      }
+    }
+  }
+
+  const inMatrix = new Set(matrixGroups());
+  const missing = ciGroups.filter((name) => !inMatrix.has(name));
+  const unknown = [...inMatrix].filter(
+    (name) => !ciGroups.includes(name as GroupName)
+  );
+  if (missing.length || unknown.length) {
+    fail(
+      `ci.yml's e2e matrix disagrees with this file.` +
+        (missing.length ? ` No matrix entry for: ${missing.join(", ")}.` : "") +
+        (unknown.length ? ` Not a CI group: ${unknown.join(", ")}.` : "")
+    );
+  }
+}
+
+assertGroupsAreComplete();
+
+export type ActiveGroup = Group & { name: GroupName };
+
+/** The group named by E2E_GROUP, or undefined for "the whole suite". */
+export function activeGroup(): ActiveGroup | undefined {
+  const name = process.env.E2E_GROUP;
+  if (!name) return undefined;
+  if (!groupNames.includes(name as GroupName)) {
+    fail(`E2E_GROUP="${name}" is not a group. Known: ${groupNames.join(", ")}`);
+  }
+  return { name: name as GroupName, ...groups[name as GroupName] };
+}
+
+/**
+ * A group boots only its own apps. With no group — every local run — that is
+ * the union of every group's apps, which is every app: derived rather than
+ * listed, so an app nothing needs cannot linger in the list. Filtering
+ * `appKeys` rather than mapping the group's own array keeps the servers in
+ * canonical port order however a group happens to list them.
+ */
+export const appsFor = (group: ActiveGroup | undefined): AppKey[] =>
+  group ? appKeys.filter((key) => group.apps.includes(key)) : appKeys;
+
+/**
+ * One line above the webServer output. Without it, a spec that reaches an app
+ * its group did not boot fails with a bare port number and nothing to tie it
+ * back to.
+ */
+export const describeGroup = (group: ActiveGroup): string =>
+  `e2e group "${group.name}": ${group.specs.join(", ")} on ` +
+  group.apps.map((app) => `${app} (${appOrigin(app)})`).join(", ");

--- a/apps/playwright/playwright.config.ts
+++ b/apps/playwright/playwright.config.ts
@@ -1,5 +1,7 @@
 import type { PlaywrightTestConfig } from "@playwright/test";
 import { devices } from "@playwright/test";
+import { activeGroup, appsFor, describeGroup } from "./e2e-groups";
+import { apps, appOrigin } from "./tests/apps";
 
 /**
  * Read environment variables from file.
@@ -8,10 +10,43 @@ import { devices } from "@playwright/test";
 // require('dotenv').config();
 
 /**
+ * `E2E_GROUP` selects one named group of specs — see e2e-groups.ts, which also
+ * asserts on load that the groups, the spec files on disk and ci.yml's matrix
+ * all agree. Setting it restricts `testMatch` to that group's files, trims
+ * `webServer` to the apps those files navigate to, and names the blob report
+ * after the group so the reports still merge.
+ *
+ * Unset means the whole suite and every server, exactly as before, which is
+ * what `pnpm e2e`, `e2e-headed` and `e2e-extension` all rely on.
+ *
+ * An env var rather than a Playwright project per group because `webServer` is
+ * config-wide: a `--project=solid-*` split would still boot all ten apps, and
+ * not booting them is most of the point.
+ */
+const group = activeGroup();
+// Main process only: Playwright re-evaluates this config in every worker, and
+// one copy of the line above the webServer output is the useful number.
+if (group && process.env.TEST_WORKER_INDEX === undefined) {
+  console.info(describeGroup(group));
+}
+
+/**
  * See https://playwright.dev/docs/test-configuration.
  */
 const config: PlaywrightTestConfig = {
   testDir: "./tests",
+  /**
+   * Only when a group is active; left undefined otherwise so the default glob
+   * still collects tests/extensions for `pnpm e2e-extension`.
+   *
+   * A pattern here is a suffix match against the absolute file path, not a
+   * path relative to `testDir`: Playwright prefixes any pattern that lacks one
+   * with a recursive wildcard. Patterns also intersect with a path passed on
+   * the command line rather than fighting it, so the `./tests/libs` in
+   * package.json's scripts keeps working. A pattern matching nothing is a
+   * "no tests found" failure, which is the backstop for a typo.
+   */
+  testMatch: group?.specs,
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
   expect: {
@@ -41,7 +76,9 @@ const config: PlaywrightTestConfig = {
    * (2) rules out slowness: the element exists and is still unreachable, which
    * points at the runtime's shadow-root mount rather than timing. getByRole
    * does not pierce closed shadow roots. Sharding only changed the timing
-   * enough to expose it; the serial pre-sharding run reported 0 flaky.
+   * enough to expose it; the serial pre-sharding run reported 0 flaky. Named
+   * groups change the timing again — basics.spec.ts now runs alone in its own
+   * job — so the rate may move either way, and one green run proves nothing.
    *
    * Two things were tried and did not help, so don't repeat them: switching
    * webServer from `port` to `url`, and a globalSetup that loaded every app in
@@ -51,22 +88,41 @@ const config: PlaywrightTestConfig = {
    */
   retries: process.env.CI ? 2 : 0,
   /**
-   * One worker per shard on CI. These specs share dev servers and mutate
-   * global settings (see settings.spec.ts), so running them concurrently
-   * against the same server is not safe. CI parallelism comes from sharding
-   * instead: each shard is a separate job with its own dev servers, so the
-   * isolation holds.
+   * One worker per job on CI. Not for isolation — that already holds without
+   * it. Playwright gives every test a fresh BrowserContext, and the only thing
+   * the runtime persists is localStorage (`LOCATOR_USER_OPTIONS`), so
+   * settings.spec.ts gets the empty store it depends on and tree-parents.spec.ts
+   * seeds its own through addInitScript. The dev servers hold no per-test state.
+   *
+   * It is for headroom: a runner has 4 vCPUs, and the `basics` group alone puts
+   * seven dev servers on them. The solid flake below is timing-sensitive, so
+   * raising this is a change to make on its own and measure, not a freebie —
+   * a per-group `workers` in e2e-groups.ts is the obvious place for it.
    */
   workers: process.env.CI ? 1 : undefined,
   /**
    * On CI: `github` annotates the failing lines directly in the PR, `list`
    * puts the failure in the job log (previously the html reporter was the
    * only one, so the log said nothing and you had to download an artifact to
-   * learn which test broke), and `blob` is what makes shard merging possible.
+   * learn which test broke), and `blob` is what makes merging possible.
+   *
+   * The blob file name has to be explicit now. It used to come for free from
+   * `--shard`, which appends the shard number; with named groups and no shard
+   * every job would write `blob-report/report.zip` and the `merge-multiple`
+   * download in the report job would keep only one of them. Note that
+   * dropping `merge-multiple` is not the alternative fix — merge-reports reads
+   * its input directory non-recursively, so one zip per subdirectory reads as
+   * no reports at all.
    */
   reporter: process.env.CI
-    ? [["github"], ["list"], ["blob"]]
+    ? [
+        ["github"],
+        ["list"],
+        ["blob", { fileName: `report-${group?.name ?? "all"}.zip` }],
+      ]
     : [["html", { open: "never" }]],
+  /** Carried per-machine into the merged report, so a result names its job. */
+  tag: group && `@${group.name}`,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
@@ -136,7 +192,7 @@ const config: PlaywrightTestConfig = {
   // outputDir: 'test-results/',
 
   /**
-   * Every server the suite needs, in one place.
+   * Every server the active group needs, in one place.
    *
    * This used to list only the four Next.js apps, leaving the rest to be
    * started by `pnpm dev` / `pnpm test-apps:dev` and waited on by a bash
@@ -158,33 +214,26 @@ const config: PlaywrightTestConfig = {
    * Note this is a readiness signal, not a warm-up. It does not fix the
    * basics.spec.ts "solid" flake; see the comment on `retries`.
    *
-   * Ports also live in test-apps/<app>/package.json and in tests/consts.ts.
-   * See scripts/dev-ports.sh for the shared source.
+   * Which servers depends on `E2E_GROUP`: a group boots only the apps its
+   * specs navigate to, which e2e-groups.ts checks against those specs' own
+   * source before anything starts. With no group this is every app, derived as
+   * the union of every group's — which is how vite-svelte-clean-project stays
+   * in the list, since tests/extensions needs it and tests/libs does not.
+   *
+   * Package names and ports live in tests/apps.ts, next to the URL map the
+   * specs import, so this package has one port list rather than two. They also
+   * live in test-apps/<app>/package.json; see scripts/dev-ports.sh for the
+   * shared source.
    */
-  webServer: [
-    ["@locator/web", "PORT_WEB", 3342],
-    ["@locator/vite-react-project", "PORT_REACT", 3343],
-    ["vite-solid-project", "PORT_SOLID", 3345],
-    ["vite-preact-project", "PORT_PREACT", 3346],
-    ["vite-svelte-project", "PORT_SVELTE", 3347],
-    ["vite-react-clean-project", "PORT_REACT_CLEAN", 3348],
-    ["vite-svelte-clean-project", "PORT_SVELTE_CLEAN", 3349],
-    ["vite-vue-project", "PORT_VUE", 3350],
-    ["next-16", "PORT_NEXT_16", 3352],
-    ["next-16-turbopack", "PORT_NEXT_16_TURBO", 3353],
-  ]
-    .map(([pkg, envVar, fallback]) => ({
-      command: `pnpm --filter ${pkg} dev`,
-      url: `http://localhost:${process.env[envVar as string] ?? fallback}/`,
-    }))
-    .map((server) => ({
-      ...server,
-      reuseExistingServer: !process.env.CI,
-      // The Next apps cold-compile on first request; be generous.
-      timeout: 120_000,
-      stdout: "pipe" as const,
-      stderr: "pipe" as const,
-    })),
+  webServer: appsFor(group).map((key) => ({
+    command: `pnpm --filter ${apps[key].pkg} dev`,
+    url: appOrigin(key),
+    reuseExistingServer: !process.env.CI,
+    // The Next apps cold-compile on first request; be generous.
+    timeout: 120_000,
+    stdout: "pipe" as const,
+    stderr: "pipe" as const,
+  })),
 };
 
 export default config;

--- a/apps/playwright/tests/apps.ts
+++ b/apps/playwright/tests/apps.ts
@@ -1,0 +1,99 @@
+/**
+ * Every app the e2e suite can point a browser at, described once.
+ *
+ * Two tables, because they answer two different questions:
+ *
+ *   `apps`  — what has to be *running*. One entry per dev server, and the only
+ *             place a package name or a port appears in this package.
+ *   `pages` — what a spec can *navigate to*, and which app serves it. Nearly
+ *             1:1 with `apps`, except `reactEmbedding`, a second page of the
+ *             same react server. consts.ts turns this into the `projects` URL
+ *             map the specs import; ../e2e-groups.ts uses it to check that a
+ *             group boots the servers its specs actually need.
+ *
+ * Ports also live in test-apps/<app>/package.json. scripts/dev-ports.sh is the
+ * shared source both read, each defaulting to its historical value, so a shell
+ * that has not sourced it behaves exactly as before.
+ */
+export type App = {
+  /** pnpm package name, for `pnpm --filter <pkg> dev`. */
+  pkg: string;
+  /** Env var scripts/dev-ports.sh exports for this app. */
+  portEnv: string;
+  /** Historical port, used when that var is unset. */
+  port: number;
+};
+
+/**
+ * In port order, which is also the order playwright.config.ts starts them in.
+ */
+export const apps = {
+  web: { pkg: "@locator/web", portEnv: "PORT_WEB", port: 3342 },
+  react: {
+    pkg: "@locator/vite-react-project",
+    portEnv: "PORT_REACT",
+    port: 3343,
+  },
+  solid: { pkg: "vite-solid-project", portEnv: "PORT_SOLID", port: 3345 },
+  preact: { pkg: "vite-preact-project", portEnv: "PORT_PREACT", port: 3346 },
+  svelte: { pkg: "vite-svelte-project", portEnv: "PORT_SVELTE", port: 3347 },
+  reactClean: {
+    pkg: "vite-react-clean-project",
+    portEnv: "PORT_REACT_CLEAN",
+    port: 3348,
+  },
+  svelteClean: {
+    pkg: "vite-svelte-clean-project",
+    portEnv: "PORT_SVELTE_CLEAN",
+    port: 3349,
+  },
+  vue: { pkg: "vite-vue-project", portEnv: "PORT_VUE", port: 3350 },
+  next16: { pkg: "next-16", portEnv: "PORT_NEXT_16", port: 3352 },
+  next16Turbopack: {
+    pkg: "next-16-turbopack",
+    portEnv: "PORT_NEXT_16_TURBO",
+    port: 3353,
+  },
+} satisfies Record<string, App>;
+
+export type AppKey = keyof typeof apps;
+
+/** Every app, in port order. */
+export const appKeys = Object.keys(apps) as AppKey[];
+
+type Page = {
+  app: AppKey;
+  /** Appended to the app's origin. Omitted means the app's root. */
+  path?: string;
+};
+
+const pages = {
+  web: { app: "web" },
+  react: { app: "react" },
+  reactEmbedding: { app: "react", path: "embedding.html" },
+  solid: { app: "solid" },
+  preact: { app: "preact" },
+  svelte: { app: "svelte" },
+  reactClean: { app: "reactClean" },
+  svelteClean: { app: "svelteClean" },
+  vue: { app: "vue" },
+  next16: { app: "next16" },
+  next16Turbopack: { app: "next16Turbopack" },
+} satisfies Record<string, Page>;
+
+export type PageKey = keyof typeof pages;
+
+/** Which server has to be running for this page to load. */
+export const appServing = (key: PageKey): AppKey => pages[key].app;
+
+export const appOrigin = (key: AppKey): string => {
+  const app = apps[key];
+  return `http://localhost:${process.env[app.portEnv] ?? app.port}/`;
+};
+
+export const pageUrl = (key: PageKey): string => {
+  // Widened because `satisfies` leaves `path` absent from the entries without
+  // one, so the union of literal types has no common `path` property.
+  const page: Page = pages[key];
+  return appOrigin(page.app) + (page.path ?? "");
+};

--- a/apps/playwright/tests/consts.ts
+++ b/apps/playwright/tests/consts.ts
@@ -1,22 +1,25 @@
-/**
- * Ports come from the same env vars that scripts/dev-ports.sh exports, each
- * defaulting to its historical value. So this behaves exactly as before unless
- * that script has been sourced, in which case the whole suite follows the
- * shifted port block.
- */
-const port = (name: string, fallback: number): string =>
-  process.env[name] ?? String(fallback);
+import { pageUrl, type PageKey } from "./apps";
 
+/**
+ * Every URL the specs navigate to. Package names and ports live in apps.ts,
+ * which is also what playwright.config.ts builds its webServer array from, so
+ * this package has one port list instead of two.
+ *
+ * Spelled out one line per page rather than generated from that table, so it
+ * stays greppable from a spec. `satisfies` is what keeps it honest: a page
+ * added to apps.ts and missed here is a type error rather than a silently
+ * absent entry, and a typo here is a type error too.
+ */
 export const projects = {
-  web: `http://localhost:${port("PORT_WEB", 3342)}/`,
-  react: `http://localhost:${port("PORT_REACT", 3343)}/`,
-  reactEmbedding: `http://localhost:${port("PORT_REACT", 3343)}/embedding.html`,
-  solid: `http://localhost:${port("PORT_SOLID", 3345)}/`,
-  preact: `http://localhost:${port("PORT_PREACT", 3346)}/`,
-  svelte: `http://localhost:${port("PORT_SVELTE", 3347)}/`,
-  reactClean: `http://localhost:${port("PORT_REACT_CLEAN", 3348)}/`,
-  svelteClean: `http://localhost:${port("PORT_SVELTE_CLEAN", 3349)}/`,
-  vue: `http://localhost:${port("PORT_VUE", 3350)}/`,
-  next16: `http://localhost:${port("PORT_NEXT_16", 3352)}/`,
-  next16Turbopack: `http://localhost:${port("PORT_NEXT_16_TURBO", 3353)}/`,
-};
+  web: pageUrl("web"),
+  react: pageUrl("react"),
+  reactEmbedding: pageUrl("reactEmbedding"),
+  solid: pageUrl("solid"),
+  preact: pageUrl("preact"),
+  svelte: pageUrl("svelte"),
+  reactClean: pageUrl("reactClean"),
+  svelteClean: pageUrl("svelteClean"),
+  vue: pageUrl("vue"),
+  next16: pageUrl("next16"),
+  next16Turbopack: pageUrl("next16Turbopack"),
+} satisfies Record<PageKey, string>;

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,8 @@
     "PORT_VUE",
     "PORT_NEXT_14",
     "PORT_NEXT_16",
-    "PORT_NEXT_16_TURBO"
+    "PORT_NEXT_16_TURBO",
+    "E2E_GROUP"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Why

CI ran the Playwright suite as `e2e (shard 1/3)`..`(3/3)`. Two problems follow from that partition:

- **A red check named nothing.** `--shard` splits *individual tests* under `fullyParallel`, so each shard was an arbitrary third of the suite drawn from all six spec files × three browsers. You had to open the log to learn what broke.
- **Every shard booted all ten dev servers** — 48s of startup, three times over — for servers most of its tests never touched. `vite-svelte-clean-project` was booted by all three shards and used by **zero** tests under `tests/libs` (only `tests/extensions`, which CI never runs). `@locator/web` is a full `next dev` that exists for exactly one test.

Every spec file already targets a small, known set of apps, so the partition was available for free.

## What

Six named jobs, each running known specs and booting only the servers those specs navigate to:

| group | spec | apps booted |
|---|---|---|
| `adapters` | `basics.spec.ts` | web, react, preact, solid, svelte, reactClean, vue |
| `tree` | `tree-parents.spec.ts` | react |
| `embedding` | `embedding.spec.ts` | react |
| `settings` | `settings.spec.ts` | solid |
| `bindings` | `binding-actions.spec.ts` | solid |
| `next` | `next16.spec.ts` | next16, next16Turbopack |

Five of the six need a single app.

`adapters` is the one that needs seven, because the thing it varies is the framework, not the depth: one shallow test per app — mount the runtime, alt-click a known text node, expect the welcome screen. That is coverage of `packages/runtime/src/adapters` (`jsx`, `react`, `svelte`, `vue`) plus react-clean as the negative control. It is not "basic functionality", which is what the file name `basics.spec.ts` reads as; the file keeps that name only to preserve the tie to the commits documenting its solid flake, and `e2e-groups.ts` says so at the group.

### Measured wall clock

Two green runs, against the `5m17` longest shard of baseline run `32584971884`:

| job | run 1 | run 2 |
|---|---|---|
| `adapters` | 3m18 | 3m05 |
| `embedding` | 3m30 | **3m38** |
| `settings` | **3m48** | 3m32 |
| `tree` | 2m48 | 2m27 |
| `bindings` | 2m48 | 2m33 |
| `next` | 2m18 | 1m55 |

**5m17 → 3m38-3m48, about 28% off the critical path.** Runner minutes go ~15 → ~19.

Framework-shaped groups (`smoke`/`react`/`solid`/`next`) were the intuitive split and the wrong one: `tree-parents + embedding` is 234s of test work, more than any current shard's share, so `e2e (react)` would have landed at ~5m25 — *worse* than what it replaced.

## Mechanism

- **`tests/apps.ts`** (new) — the single description of each app (package name, port env var, fallback port) and each page. `tests/consts.ts` now derives the `projects` URL map from it; same shape, same values, so **no spec file changed**, and ports stop living in two files inside this package.
- **`e2e-groups.ts`** (new) — the group table. `E2E_GROUP` selects one; unset means the whole suite and all ten servers, so `pnpm e2e`, `e2e-headed` and `e2e-extension` are unchanged. The no-group server list is the *union of every group's apps*, which is how svelte-clean stays in it — declared by a non-CI `extension` group rather than sitting there unexplained.
- An env var rather than a Playwright project per group because `webServer` is config-wide: a `--project=solid-*` split would still boot all ten apps, and not booting them is most of the point.

## The guard

Naming the jobs means the mapping can rot, and every way it rots is silent. `e2e-groups.ts` throws at config load — before any server starts, in CI *and* in a plain `pnpm e2e` — if:

1. a spec file on disk belongs to no group;
2. a group omits an app its specs navigate to (read off the specs' own source);
3. the group list and `ci.yml`'s matrix disagree in either direction.

All four failure paths were exercised by hand, and (3) then earned its place for real: the `basics` → `adapters` rename in this PR was caught by it before `ci.yml` was touched.

```
e2e-groups.ts: no group runs tests/libs/zz-orphan.spec.ts. Add each to a group's `specs`
e2e-groups.ts: tests/libs/basics.spec.ts navigates to the "vue" app, but group "adapters" does not boot it — add "vue" to its `apps`
e2e-groups.ts: ci.yml's e2e matrix disagrees with this file. No matrix entry for: adapters. Not a CI group: basics.
e2e-groups.ts: E2E_GROUP="solid" is not a group. Known: adapters, tree, embedding, settings, bindings, next, extension
```

## Also in here

- **The blob file name is now explicit.** It used to come free from `--shard`, which appends the shard number. Without a shard all six jobs would write `blob-report/report.zip` and the `merge-multiple: true` download would keep one of them. Dropping `merge-multiple` is *not* the alternative — `merge-reports` reads its input directory non-recursively. Verified in CI: the report job extracted all six of `report-adapters.zip` … `report-tree.zip`.
- **The `workers` comment was wrong** and is corrected. It claimed the specs "mutate global settings … so running them concurrently is not safe". They don't: every test gets a fresh `BrowserContext`, and the only persistence is `localStorage.LOCATOR_USER_OPTIONS` — `settings.spec.ts` relies on starting empty and does, `tree-parents.spec.ts` seeds via `addInitScript`, and the dev servers are stateless. The value stays `1`, for CPU headroom on a 4-vCPU runner. Raising it is a measured follow-up.
- `E2E_GROUP` added to `turbo.json`'s `globalEnv` — turbo 2 defaults to strict env mode, so without it `E2E_GROUP=next pnpm e2e` would silently run the whole suite.
- `AGENTS.md` updated in three places, including a rough-edge note about required check names.

## Tried and reverted: caching the browsers

Worth recording, since six jobs each running `playwright install --with-deps` looks like obvious waste. It isn't cacheable. Run `32628277049` cached `~/.cache/ms-playwright`, hit the cache, and downloaded **no** browsers at all — and the step still took 24-57s, because `--with-deps` also installs the system libraries the browsers need and those are apt packages, outside any path a cache can hold. ~15s of downloads saved against ~7s of restore, on a step whose own variance is 33s; mean cache+install across the six jobs went 43s cold to 45s warm. Removed in `ed9dfab`, with the measurement left in the comment so the next person doesn't re-run the experiment.

## Verified

- `pnpm check` — green locally and in CI.
- **No-group parity:** `playwright test --list ./tests/libs` still reports 168 tests in 6 files; `./tests/extensions` still collects 9. The `projects` URL map produces byte-identical URLs on the historical defaults *and* still shifts correctly under `PORT=45000 . ./scripts/dev-ports.sh`.
- **Group coverage:** 21 + 42 + 51 + 15 + 12 + 27 = **168**. No gaps, no overlap.
- **Server filtering, for real:** `CI=1 E2E_GROUP=tree playwright test --project=chromium` booted `@locator/vite-react-project` and nothing else.
- **Merging across groups:** locally over two blobs, and in CI over all six.

## One thing to do at merge time

The `e2e (shard 1/3)`, `(2/3)`, `(3/3)` check names cease to exist and six new ones appear. **Branch protection's required status checks need updating** or PRs will wait forever on checks that never report.

Related fact worth knowing while you're in there: `e2e report` was never a gate — `merge-reports` exits 0 whatever the tests did, so that job is green on a red suite. The `e2e (<group>)` jobs are the checks. Noted in `ci.yml` and `AGENTS.md`.

## Deliberately not in scope

- **Per-group `workers`.** `embedding` is 51 test-runs and would roughly halve at 3 workers — the largest remaining win. Landing the rename first keeps any change in flake rate attributable to one thing.
- **The `basics.spec.ts` "solid" flake.** It survived, as the `retries` comment predicts: run 1 had it fail attempt 1 in chromium and pass on retry (`1 flaky`). It now lands in `e2e (adapters)` and stops wandering between shards, which makes it attributable for the first time — but one run is not evidence of a changed rate.
- `test-apps/next-14` is orphaned: in `dev-ports.sh` and `turbo.json`, but in no `webServer` entry and no `consts.ts` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)