### PR TITLE
Fix settings isolation, migration, and browser compatibility

### DIFF
--- a/apps/extension/src/pages/Background/index.test.ts
+++ b/apps/extension/src/pages/Background/index.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  onMessage: vi.fn(),
+  get: vi.fn(),
+  initialize: vi.fn(),
+}));
+vi.mock('../../browser', () => ({
+  default: {
+    runtime: {
+      id: 'locator-extension',
+      onMessage: { addListener: mocks.onMessage },
+      onInstalled: { addListener: vi.fn() },
+    },
+    storage: { local: { get: mocks.get } },
+    tabs: {
+      onUpdated: { addListener: vi.fn() },
+      onRemoved: { addListener: vi.fn() },
+    },
+  },
+}));
+vi.mock('../../storageContract', () => ({
+  ensureExtensionStorageReady: mocks.initialize,
+}));
+vi.mock('../../extensionUpdateState', () => ({
+  clearTabReloadRequirement: vi.fn(),
+  recordExtensionUpdate: vi.fn(),
+}));
+
+const request = { from: 'content', subject: 'documentOrigin' };
+const origin = 'https://app.example';
+const sender = {
+  id: 'locator-extension',
+  tab: { id: 7 },
+  frameId: 0,
+  origin,
+};
+
+function dispatch(message: unknown = request, identity: unknown = sender) {
+  const sendResponse = vi.fn();
+  const returned = mocks.onMessage.mock.calls[0][0](
+    message,
+    identity,
+    sendResponse
+  );
+  // Older Chromium ignores returned Promises. Observe rejection only to keep
+  // a broken listener from leaking an unhandled rejection in this harness.
+  if (returned instanceof Promise) void returned.catch(() => undefined);
+  return { returned, sendResponse };
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.get.mockResolvedValue({});
+  await import('./index');
+});
+
+test('registers the listener without waiting for storage initialization', () => {
+  expect(mocks.onMessage).toHaveBeenCalledOnce();
+  expect(mocks.initialize).not.toHaveBeenCalled();
+});
+
+test.each([
+  ['http://localhost:3000', {}, 'localhost'],
+  [origin, { [`trustedOrigin:${origin}`]: true }, 'approved'],
+  [origin, {}, 'approval-required'],
+])(
+  'answers %s through the callback (%s, %s)',
+  async (value, stored, reason) => {
+    mocks.get.mockResolvedValue(stored);
+    const { returned, sendResponse } = dispatch(request, {
+      ...sender,
+      origin: value,
+    });
+    expect(returned).toBe(true);
+    await vi.waitFor(() =>
+      expect(sendResponse.mock.calls).toEqual([
+        [
+          {
+            origin: value,
+            access: { origin: value, reason },
+          },
+        ],
+      ])
+    );
+  }
+);
+
+test.each([
+  { ...sender, id: 'another-extension' },
+  { ...sender, id: undefined },
+  { ...sender, tab: undefined },
+  { ...sender, tab: { id: '7' } },
+  { ...sender, frameId: undefined },
+  { ...sender, frameId: '0' },
+])('rejects an unauthenticated sender: %j', (identity) => {
+  const { returned, sendResponse } = dispatch(request, identity);
+  expect(sendResponse.mock.calls).toEqual([[{ origin: null }]]);
+  expect(returned).toBe(false);
+  expect(mocks.get).not.toHaveBeenCalled();
+});
+
+test.each([origin, undefined])(
+  'uses only browser-supplied origin (%s), ignoring payload and sender URL',
+  async (value) => {
+    const { returned, sendResponse } = dispatch(
+      { ...request, origin: 'http://localhost:3000' },
+      { ...sender, origin: value, url: 'http://localhost:3000' }
+    );
+    expect(returned).toBe(true);
+    await vi.waitFor(() =>
+      expect(sendResponse.mock.calls).toEqual([
+        [
+          {
+            origin: value ?? null,
+            access: {
+              origin: value ?? null,
+              reason: value ? 'approval-required' : 'unavailable',
+            },
+          },
+        ],
+      ])
+    );
+    if (value) expect(mocks.get).toHaveBeenCalledWith(`trustedOrigin:${value}`);
+    else expect(mocks.get).not.toHaveBeenCalled();
+  }
+);
+
+test.each([
+  null,
+  {},
+  { ...request, subject: 'other' },
+  { ...request, from: 'page' },
+])('leaves unrelated messages to other listeners: %j', (message) => {
+  const { returned, sendResponse } = dispatch(message);
+  expect(returned).toBe(false);
+  expect(sendResponse).not.toHaveBeenCalled();
+  expect(mocks.get).not.toHaveBeenCalled();
+});
+
+test('answers unavailable when the origin lookup rejects', async () => {
+  mocks.get.mockRejectedValue(new Error('Storage unavailable'));
+  const { returned, sendResponse } = dispatch();
+  expect(returned).toBe(true);
+  await vi.waitFor(() =>
+    expect(sendResponse.mock.calls).toEqual([[{ origin: null }]])
+  );
+});

--- a/apps/extension/src/pages/Background/index.ts
+++ b/apps/extension/src/pages/Background/index.ts
@@ -18,24 +18,28 @@ browser.runtime.onInstalled.addListener((details) => {
 // This listener is deliberately registered before any storage initialization.
 // The browser supplies the authenticated document origin; page-world fields
 // and sender URLs are never used as fallbacks.
-browser.runtime.onMessage.addListener((message, sender) => {
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message?.from !== 'content' || message.subject !== 'documentOrigin') {
     return false;
   }
   const senderId = (sender as { id?: string }).id;
   if (senderId !== browser.runtime.id) {
-    return { origin: null };
+    sendResponse({ origin: null });
+    return false;
   }
   if (
     typeof sender.tab?.id !== 'number' ||
     typeof sender.frameId !== 'number'
   ) {
-    return { origin: null };
+    sendResponse({ origin: null });
+    return false;
   }
-  return getOriginAccess(sender.origin).then((access) => ({
-    origin: access.origin,
-    access,
-  }));
+  void getOriginAccess(sender.origin).then(
+    (access) => sendResponse({ origin: access.origin, access }),
+    () => sendResponse({ origin: null })
+  );
+  // Keep the response channel open in Chromium versions that ignore Promises.
+  return true;
 });
 
 browser.tabs.onUpdated.addListener((tabId, changeInfo) => {

--- a/apps/extension/src/pages/Popup/Home.tsx
+++ b/apps/extension/src/pages/Popup/Home.tsx
@@ -168,9 +168,12 @@ export function Home() {
             disabled: extensionNeedsReset(),
             disabledReason:
               'Reset the preview settings before editing All sites.',
-            editLayers: {
-              default: DEFAULT_LAYER,
-              'user-extension': userExtension(),
+            editContext: {
+              layers: {
+                default: DEFAULT_LAYER,
+                'user-extension': userExtension(),
+              },
+              targets: ALL_TARGETS,
             },
           },
         ]}

--- a/apps/extension/src/pages/Popup/Popup.test.tsx
+++ b/apps/extension/src/pages/Popup/Popup.test.tsx
@@ -1,5 +1,11 @@
 import { strictConfig } from '@locator/shared';
-import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@solidjs/testing-library';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ConnectivityStatus, Snapshot } from './syncedState';
 
@@ -84,6 +90,32 @@ function connectedSnapshot(): Snapshot {
   };
 }
 
+const PAGE_TEMPLATE = 'https://page.example/source?file=${filePath}';
+
+function pageTargetSnapshot(): Snapshot {
+  const snapshot = connectedSnapshot();
+  return {
+    ...snapshot,
+    layers: {
+      ...snapshot.layers,
+      team: { editor: { kind: 'target', id: 'page-editor' } },
+      'user-origin': {
+        editor: { kind: 'target', id: 'page-editor' },
+        projectPath: '/this-site',
+      },
+    },
+    allTargets: {
+      vscode: { label: 'VSCode', url: PAGE_TEMPLATE },
+      'page-editor': { label: 'Page editor', url: PAGE_TEMPLATE },
+    },
+  };
+}
+
+async function chooseScope(label: 'This site' | 'All sites') {
+  await screen.getByRole('combobox', { name: 'Settings scope' }).click();
+  await fireEvent.click(await screen.findByRole('option', { name: label }));
+}
+
 describe('Popup settings navigation', () => {
   beforeEach(() => {
     mocks.setStatus('connected');
@@ -95,6 +127,119 @@ describe('Popup settings navigation', () => {
   });
 
   afterEach(cleanup);
+
+  test('All sites customizes its trusted editor instead of the page target', async () => {
+    mocks.userExtension = { editor: { kind: 'target', id: 'vscode' } };
+    mocks.setSnapshot(pageTargetSnapshot());
+    render(() => <Popup />);
+
+    await chooseScope('All sites');
+    await screen
+      .getByRole('button', { name: 'Customize link template' })
+      .click();
+    await fireEvent.keyDown(
+      screen.getByRole('textbox', { name: 'Custom link template' }),
+      { key: 'Enter' }
+    );
+
+    await waitFor(() =>
+      expect(mocks.setUserExtension).toHaveBeenCalledWith({
+        set: {
+          editor: {
+            kind: 'template',
+            template: strictConfig.targetRegistryView(
+              strictConfig.BUILT_IN_TARGETS
+            ).vscode.url,
+          },
+        },
+      })
+    );
+    expect(mocks.setSiteLocal).not.toHaveBeenCalled();
+  });
+
+  test('switching to All sites discards the page-seeded custom editor draft', async () => {
+    mocks.userExtension = { editor: { kind: 'target', id: 'vscode' } };
+    mocks.setSnapshot(pageTargetSnapshot());
+    render(() => <Popup />);
+
+    await screen
+      .getByRole('button', { name: 'Customize link template' })
+      .click();
+    expect(
+      (
+        screen.getByRole('textbox', {
+          name: 'Custom link template',
+        }) as HTMLInputElement
+      ).value
+    ).toBe(PAGE_TEMPLATE);
+    await chooseScope('All sites');
+
+    expect(
+      screen.queryByRole('textbox', { name: 'Custom link template' })
+    ).toBeNull();
+    expect(mocks.setUserExtension).not.toHaveBeenCalled();
+    expect(mocks.setSiteLocal).not.toHaveBeenCalled();
+
+    await screen
+      .getByRole('button', { name: 'Customize link template' })
+      .click();
+    const input = screen.getByRole('textbox', { name: 'Custom link template' });
+    const manualTemplate = 'https://my-editor.example/open?file=${filePath}';
+    await fireEvent.input(input, { target: { value: manualTemplate } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() =>
+      expect(mocks.setUserExtension).toHaveBeenCalledWith({
+        set: { editor: { kind: 'template', template: manualTemplate } },
+      })
+    );
+  });
+
+  test('an unset All sites editor stays unset while This site keeps its custom target', async () => {
+    mocks.userExtension = {};
+    mocks.setSnapshot(pageTargetSnapshot());
+    render(() => <Popup />);
+
+    expect(
+      screen.getByRole('combobox', { name: 'Editor' }).textContent
+    ).toContain('Page editor');
+    await chooseScope('All sites');
+    expect(
+      screen.getByRole('combobox', { name: 'Editor' }).textContent
+    ).toContain('Select editor');
+    expect(
+      screen.getByText('Pick an editor so source links can open.')
+    ).toBeTruthy();
+    expect(mocks.setUserExtension).not.toHaveBeenCalled();
+
+    await screen.getByRole('button', { name: 'Advanced settings' }).click();
+    expect(
+      (
+        screen.getByRole('textbox', {
+          name: 'Project path',
+        }) as HTMLInputElement
+      ).value
+    ).toBe('');
+    expect(screen.getByText(/Project path: \/this-site/)).toBeTruthy();
+    await screen.getByRole('button', { name: 'Back to interactions' }).click();
+    await chooseScope('This site');
+    await screen.getByRole('combobox', { name: 'Editor' }).click();
+    await fireEvent.click(
+      await screen.findByRole('option', { name: 'Page editor' })
+    );
+    await screen
+      .getByRole('button', { name: 'Customize link template' })
+      .click();
+    await fireEvent.keyDown(
+      screen.getByRole('textbox', { name: 'Custom link template' }),
+      { key: 'Enter' }
+    );
+    await waitFor(() =>
+      expect(mocks.setSiteLocal).toHaveBeenCalledWith({
+        set: { editor: { kind: 'template', template: PAGE_TEMPLATE } },
+      })
+    );
+    expect(mocks.setUserExtension).not.toHaveBeenCalled();
+  });
 
   test('selects interactions in place and preserves the selected site scope', async () => {
     render(() => <Popup />);

--- a/apps/playwright/tests/libs/next16.spec.ts
+++ b/apps/playwright/tests/libs/next16.spec.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { test, expect, Page } from "@playwright/test";
 import { projects } from "../consts";
 import { locateElement } from "../locateElement";
@@ -25,10 +26,16 @@ type ResolvedSource = {
   columnNumber?: number;
 };
 
-async function configureEditor(page: Page) {
+type NextApp = "next-16" | "next-16-turbopack";
+
+async function configureEditor(page: Page, app: NextApp) {
   await seedLocatorStorage(
     page,
-    { editor: { kind: "target", id: "vscode" } },
+    {
+      editor: { kind: "target", id: "vscode" },
+      // Webpack can supply a project-relative source; configure its local root.
+      projectPath: resolve(__dirname, "../../../../test-apps", app),
+    },
     {
       welcomeScreenDismissed: true,
       onboarding: { dismissed: true, step: "done" },
@@ -79,7 +86,7 @@ async function expectFileInAppSource(page: Page, appPath: RegExp) {
 
 async function expectExactUserSource(
   page: Page,
-  expected: { file: RegExp; line: number }
+  expected: { app: NextApp; line: number }
 ) {
   await expect
     .poll(
@@ -101,15 +108,19 @@ async function expectExactUserSource(
   expect(openedUrl).not.toMatch(
     /(?:node_modules|webpack-internal:|react-jsx-dev-runtime|\/_next\/|\/\.next\/)/
   );
-  expect(decodeURIComponent(openedUrl).replace(/:\d+:\d+$/, "")).toMatch(
-    expected.file
+  expect(openedUrl).toMatch(/^vscode:\/\/file\//);
+  const openedFile = decodeURIComponent(openedUrl)
+    .replace(/^vscode:\/\/file\//, "")
+    .replace(/:\d+:\d+$/, "");
+  expect(openedFile).toBe(
+    resolve(__dirname, "../../../../test-apps", expected.app, "app/page.tsx")
   );
   expect(openedUrl).toMatch(new RegExp(`:${expected.line}:\\d+$`));
 }
 
 test.describe("Next.js 16 + Webpack (React 19)", () => {
   test("heading", async ({ page, browserName }) => {
-    await configureEditor(page);
+    await configureEditor(page, "next-16");
     await page.goto(projects.next16);
     await expectLocatorReady(page);
     await enableDebug(page);
@@ -123,13 +134,13 @@ test.describe("Next.js 16 + Webpack (React 19)", () => {
       return;
     }
     await expectExactUserSource(page, {
-      file: /(?:test-apps\/next-16)?\/app\/page\.tsx$/,
+      app: "next-16",
       line: 8,
     });
   });
 
   test("anchor element", async ({ page, browserName }) => {
-    await configureEditor(page);
+    await configureEditor(page, "next-16");
     await page.goto(projects.next16);
     await expectLocatorReady(page);
     await enableDebug(page);
@@ -141,7 +152,7 @@ test.describe("Next.js 16 + Webpack (React 19)", () => {
       return;
     }
     await expectExactUserSource(page, {
-      file: /(?:test-apps\/next-16)?\/app\/page\.tsx$/,
+      app: "next-16",
       line: 30,
     });
   });
@@ -193,6 +204,7 @@ test.describe("Next.js 16 + Turbopack (React 19, no webpack-loader)", () => {
   });
 
   test("server component heading", async ({ page, browserName }) => {
+    await configureEditor(page, "next-16-turbopack");
     await page.goto(projects.next16Turbopack);
     await expectLocatorReady(page);
     await enableDebug(page);
@@ -205,8 +217,10 @@ test.describe("Next.js 16 + Turbopack (React 19, no webpack-loader)", () => {
       await expectNoSource(page);
       return;
     }
-    await expectWelcome(page);
-    await expectFileInAppSource(page, /test-apps\/next-16-turbopack\/app\//);
+    await expectExactUserSource(page, {
+      app: "next-16-turbopack",
+      line: 7,
+    });
   });
 
   test("nested text element", async ({ page }) => {
@@ -225,7 +239,7 @@ test.describe("Turbopack debug diagnostics", () => {
   test("pointer movement does not cancel an accepted click", async ({
     page,
   }) => {
-    await configureEditor(page);
+    await configureEditor(page, "next-16-turbopack");
     await page.goto(projects.next16Turbopack);
     await expectLocatorReady(page);
     await page.evaluate(() => {

--- a/packages/runtime/src/adapters/react/resolveOriginalPosition.test.ts
+++ b/packages/runtime/src/adapters/react/resolveOriginalPosition.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import type { Fiber } from "@locator/shared";
+import { strictConfig, type Fiber } from "@locator/shared";
+import { buildLink } from "../../functions/buildLink";
 import {
   resetSourceResolutionCaches,
   resolveSourceFromFiber,
@@ -84,6 +85,60 @@ test.each([true, false])(
       lineNumber: 10,
       columnNumber: 5,
     });
+  }
+);
+
+test.each(["Server", "Prerender", "Prefetch", "Prefetchable", "FutureStage"])(
+  "opens the exact original file from a React %s stack",
+  async (environment) => {
+    mockFetch(() => undefined);
+    const compiled = strictConfig.compileSetup({
+      projectPath: "/repo",
+      editor: { kind: "target", id: "vscode" },
+    });
+    if (!compiled.ok) throw new Error("Invalid editor fixture.");
+    const effective = strictConfig.effectiveOptions(
+      strictConfig.resolveConfig(
+        { default: strictConfig.DEFAULT_LAYER, team: compiled.value.layer },
+        compiled.value.targets
+      )
+    );
+    if (effective.editor.kind !== "selected") {
+      throw new Error("Editor fixture needs a selected editor.");
+    }
+    const source = await resolveSourceFromFiber({
+      _debugStack: {
+        stack: `Error\n    at Page (about://React/${environment}/file:///repo/app/page.tsx?42:8:3)`,
+      },
+    } as unknown as Fiber);
+    expect(source).not.toBeNull();
+    if (!source) throw new Error("Expected original source.");
+    expect(
+      buildLink(
+        {
+          filePath: source.fileName,
+          line: source.lineNumber,
+          column: source.columnNumber ?? 1,
+          pathKind: source.pathKind,
+          projectPath: "",
+        },
+        { effective: () => effective },
+        effective.editor
+      )
+    ).toBe("vscode://file//repo/app/page.tsx:8:3");
+    expect(source.pathKind).toBe("absolute");
+  }
+);
+
+test.each(["about://React//file:///repo/app/page.tsx", "about://React/Server"])(
+  "does not resolve malformed wrapper %s as original source",
+  async (fileName) => {
+    mockFetch(() => undefined);
+    expect(
+      await resolveSourceFromFiber({
+        _debugStack: { stack: `Error\n    at Page (${fileName}:8:3)` },
+      } as unknown as Fiber)
+    ).toBeNull();
   }
 );
 

--- a/packages/runtime/src/adapters/react/stackFrame.test.ts
+++ b/packages/runtime/src/adapters/react/stackFrame.test.ts
@@ -11,6 +11,9 @@ import {
 
 describe("isCompiledSourceLocation", () => {
   test.each([
+    "about://React//file:///repo/app/page.tsx",
+    "about://React/Server",
+    "about:blank",
     "webpack-internal:///app/page.js",
     "webpack:///app/page.js",
     "blob:http://localhost/id",
@@ -27,6 +30,9 @@ describe("isCompiledSourceLocation", () => {
 
 describe("isOriginalUserSource", () => {
   test.each([
+    "about://React//file:///repo/app/page.tsx",
+    "about://React/Server",
+    "about:blank",
     "webpack-internal:///app/page.js",
     "/repo/node_modules/react/jsx-runtime.js",
     "/repo/node_modules/@locator/runtime/dist/index.js",
@@ -43,18 +49,22 @@ describe("parseStackFrame - forms that used to fail entirely", () => {
   // The old regexes matched the filename with `([^:]+)`, which cannot match a
   // scheme-prefixed name. Every one of these returned null, so the React 19
   // Server Components strategy was dead code for real input.
-  test("React Server Components frame", () => {
-    expect(
-      parseStackFrame(
-        "    at Page (about://React/Server/file:///Users/me/app/page.tsx:5:3)"
-      )
-    ).toMatchObject({
-      fileName: "/Users/me/app/page.tsx",
-      lineNumber: 5,
-      columnNumber: 3,
-      functionName: "Page",
-    });
-  });
+  test.each(["Server", "Prerender", "Prefetch", "Prefetchable", "FutureStage"])(
+    "React %s Components frame",
+    (environment) => {
+      const rawFileName = `about://React/${environment}/file:///Users/me/app/page.tsx?42`;
+      expect(parseStackFrame(`    at Page (${rawFileName}:5:3)`)).toMatchObject(
+        {
+          rawFileName,
+          pathKind: "absolute",
+          fileName: "/Users/me/app/page.tsx",
+          lineNumber: 5,
+          columnNumber: 3,
+          functionName: "Page",
+        }
+      );
+    }
+  );
 
   test("http chunk URL", () => {
     expect(
@@ -132,10 +142,25 @@ describe("parseStackFrame - other shapes", () => {
 });
 
 describe("cleanStackFileName", () => {
-  test("strips the RSC scheme and the file:// prefix", () => {
-    expect(
-      cleanStackFileName("about://React/Server/file:///Users/me/a.tsx")
-    ).toBe("/Users/me/a.tsx");
+  test.each(["Server", "Prerender", "Prefetch", "Prefetchable", "FutureStage"])(
+    "strips the React %s wrapper and the file:// prefix",
+    (environment) => {
+      expect(
+        cleanStackFileName(
+          `about://React/${environment}/file:///Users/me/a.tsx?42`
+        )
+      ).toBe("/Users/me/a.tsx");
+    }
+  );
+
+  test.each([
+    "about://React//file:///repo/app/page.tsx",
+    "about://React/Server",
+  ])("leaves malformed wrapper %s unsupported", (fileName) => {
+    expect(cleanStackFileName(fileName)).toBe(fileName);
+    const frame = parseStackFrame(`    at Page (${fileName}:5:3)`);
+    expect(frame?.pathKind).toBeUndefined();
+    expect(isOriginalUserSource(frame!.fileName)).toBe(false);
   });
 
   test("drops a Turbopack chunk query", () => {

--- a/packages/runtime/src/adapters/react/stackFrame.ts
+++ b/packages/runtime/src/adapters/react/stackFrame.ts
@@ -74,7 +74,7 @@ export function isLocatorFrame(fileName: string): boolean {
 export function isCompiledSourceLocation(fileName: string): boolean {
   const normalized = fileName.replace(/\\/g, "/");
   return (
-    /^(?:https?:|webpack(?:-internal)?:|blob:)/i.test(normalized) ||
+    /^(?:https?:|webpack(?:-internal)?:|blob:|about:)/i.test(normalized) ||
     normalized.includes("/_next/") ||
     normalized.includes("/.next/")
   );
@@ -89,18 +89,17 @@ export function isOriginalUserSource(fileName: string): boolean {
   );
 }
 
+/** React names the render environment in its virtual URL, e.g. Prerender. */
+function unwrapReactFileName(fileName: string): string {
+  return fileName.replace(/^about:\/\/React\/[^/]+\/(.+)$/, "$1");
+}
+
 /**
  * Clean up a stack frame file path.
  * `about://React/Server/file:///path` -> `/path`, and chunk query params go.
  */
 export function cleanStackFileName(fileName: string): string {
-  let cleaned = fileName;
-
-  if (cleaned.startsWith("about://React/Server/")) {
-    cleaned = cleaned.slice("about://React/Server/".length);
-  }
-
-  cleaned = fileUrlToPath(cleaned);
+  let cleaned = fileUrlToPath(unwrapReactFileName(fileName));
 
   const queryIndex = cleaned.indexOf("?");
   if (queryIndex !== -1) {
@@ -118,11 +117,9 @@ function toFrame(
   if (!match) return undefined;
   const [, rawFileName, line, column] = match;
   if (!rawFileName || !line || !column) return undefined;
-  const unwrapped = rawFileName.startsWith("about://React/Server/")
-    ? rawFileName.slice("about://React/Server/".length)
-    : rawFileName;
+  const unwrapped = unwrapReactFileName(rawFileName);
   return {
-    fileName: cleanStackFileName(unwrapped),
+    fileName: cleanStackFileName(rawFileName),
     rawFileName,
     lineNumber: parseInt(line, 10),
     columnNumber: parseInt(column, 10),

--- a/packages/runtime/src/functions/optionsStore.test.ts
+++ b/packages/runtime/src/functions/optionsStore.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { strictConfig, strictConfigStorage } from "@locator/shared";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { initOptions, type OptionsStore } from "./optionsStore";
 import { mountRuntimePopupBridge } from "./popupBridge";
 import {
@@ -56,8 +56,36 @@ function resetState() {
 }
 
 beforeEach(resetState);
+afterEach(() => vi.restoreAllMocks());
 
 describe("optionsStore integration", () => {
+  test("legacy opt-out and UI choices stay effective when migration cannot write", async () => {
+    localStorage.setItem(
+      strictConfigStorage.LEGACY_SITE_STORAGE_KEY,
+      JSON.stringify({
+        disabled: true,
+        templateOrTemplateId: "webstorm",
+        welcomeScreenDismissed: true,
+      })
+    );
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Full", "QuotaExceededError");
+    });
+    const options = withStore(() => initOptions());
+
+    expect(options.effective().disabled).toBe(true);
+    expect(options.provenance().disabled).toBe("user-origin");
+    expect(options.effective().editor).toMatchObject({
+      kind: "selected",
+      destination: { kind: "target", id: "webstorm" },
+    });
+    expect(options.uiState()).toEqual({ welcomeScreenDismissed: true });
+    await expect(
+      options.setUserOrigin({ set: { disabled: false } })
+    ).resolves.toEqual({ ok: false, reason: "quota" });
+    expect(options.effective().disabled).toBe(true);
+  });
+
   test("a late setup snapshot atomically re-drives resolution", () => {
     const options = withStore(() => initOptions());
     expect(options.effective().projectPath).toBeNull();

--- a/packages/shared/src/configStorage.test.ts
+++ b/packages/shared/src/configStorage.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { encodeLayer } from "./config";
 import {
   LEGACY_SITE_STORAGE_KEY,
@@ -142,6 +142,162 @@ describe("strict configuration storage", () => {
       version: 1,
       state: { welcomeScreenDismissed: true },
     });
+  });
+
+  test("retains usable legacy choices during quota failure and retries later", () => {
+    const legacy = JSON.stringify({
+      disabled: true,
+      templateOrTemplateId: "webstorm",
+      welcomeScreenDismissed: true,
+    });
+    localStorage.setItem(LEGACY_SITE_STORAGE_KEY, legacy);
+    const write = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("Full", "QuotaExceededError");
+    });
+
+    expect(readUserConfig()).toMatchObject({
+      kind: "ready",
+      revision: 0,
+      layer: { disabled: true, editor: { kind: "target", id: "webstorm" } },
+    });
+    expect(readUiState()).toEqual({ welcomeScreenDismissed: true });
+    expect(patchUserConfig({ set: { disabled: false } })).toEqual({
+      ok: false,
+      reason: "quota",
+    });
+    expect(patchUiState({ welcomeScreenDismissed: false })).toEqual({
+      ok: false,
+      reason: "quota",
+    });
+    expect(localStorage.getItem(LEGACY_SITE_STORAGE_KEY)).toBe(legacy);
+
+    write.mockRestore();
+    expect(readUserConfig()).toMatchObject({
+      kind: "ready",
+      revision: 0,
+      layer: { disabled: true },
+    });
+    expect(readUiState()).toEqual({ welcomeScreenDismissed: true });
+    expect(localStorage.getItem(LEGACY_SITE_STORAGE_KEY)).toBeNull();
+    expect(storedJson(USER_CONFIG_STORAGE_KEY)).toMatchObject({
+      version: 3,
+      layer: { disabled: true },
+    });
+  });
+
+  test("reset cannot resurrect config after a partial migration", () => {
+    localStorage.setItem(
+      LEGACY_SITE_STORAGE_KEY,
+      JSON.stringify({ disabled: true, welcomeScreenDismissed: true })
+    );
+    const setItem = localStorage.setItem.bind(localStorage);
+    vi.spyOn(localStorage, "setItem").mockImplementation((key, value) => {
+      if (key === UI_STATE_STORAGE_KEY) throw new Error("Blocked");
+      setItem(key, value);
+    });
+    expect(readUserConfig()).toMatchObject({
+      kind: "ready",
+      layer: { disabled: true },
+    });
+    expect(readUiState()).toEqual({ welcomeScreenDismissed: true });
+    expect(localStorage.getItem(LEGACY_SITE_STORAGE_KEY)).not.toBeNull();
+
+    expect(clearUserConfig().ok).toBe(true);
+    expect(localStorage.getItem(LEGACY_SITE_STORAGE_KEY)).toBeNull();
+    expect(readUserConfig()).toEqual({ kind: "empty" });
+  });
+
+  test("a blocked legacy deletion fails reset before deleting current config", () => {
+    patchUserConfig({ set: { disabled: false } });
+    localStorage.setItem(
+      LEGACY_SITE_STORAGE_KEY,
+      JSON.stringify({ disabled: true })
+    );
+    const current = localStorage.getItem(USER_CONFIG_STORAGE_KEY);
+    const removeItem = localStorage.removeItem.bind(localStorage);
+    vi.spyOn(localStorage, "removeItem").mockImplementation((key) => {
+      if (key === LEGACY_SITE_STORAGE_KEY) throw new Error("Blocked");
+      removeItem(key);
+    });
+
+    expect(clearUserConfig()).toEqual({ ok: false, reason: "blocked" });
+    expect(localStorage.getItem(USER_CONFIG_STORAGE_KEY)).toBe(current);
+    expect(readUserConfig()).toMatchObject({
+      kind: "ready",
+      layer: { disabled: false },
+    });
+  });
+
+  test.each(["{broken", "null", '{"adapterId":"unknown"}'])(
+    "discards unusable legacy data %s and allows fresh settings",
+    (legacy) => {
+      localStorage.setItem(LEGACY_SITE_STORAGE_KEY, legacy);
+      expect(readUserConfig()).toEqual({ kind: "empty" });
+      expect(readUiState()).toEqual({});
+      expect(localStorage.getItem(LEGACY_SITE_STORAGE_KEY)).toBeNull();
+      expect(patchUserConfig({ set: { disabled: true } }).ok).toBe(true);
+    }
+  );
+
+  test.each([
+    ['{"version":3,"revision":2,"layer":{"disabled":false}}', "ready"],
+    ["{broken", "corrupt"],
+    ['{"version":99}', "future-version"],
+  ])(
+    "current config %s remains authoritative when legacy writes fail",
+    (current, kind) => {
+      localStorage.setItem(USER_CONFIG_STORAGE_KEY, current);
+      localStorage.setItem(
+        LEGACY_SITE_STORAGE_KEY,
+        JSON.stringify({ disabled: true, welcomeScreenDismissed: true })
+      );
+      vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+        throw new Error("Blocked");
+      });
+      const read = readUserConfig();
+      expect(read.kind).toBe(kind);
+      if (read.kind === "ready")
+        expect(encodeLayer(read.layer)).toEqual({ disabled: false });
+      expect(localStorage.getItem(USER_CONFIG_STORAGE_KEY)).toBe(current);
+      expect(readUiState()).toEqual({ welcomeScreenDismissed: true });
+    }
+  );
+
+  test.each([
+    [
+      '{"version":1,"state":{"welcomeScreenDismissed":false}}',
+      { welcomeScreenDismissed: false },
+    ],
+    ["{broken", {}],
+    ['{"version":99,"state":{}}', {}],
+  ])(
+    "current UI %s remains authoritative and survives config reset",
+    (current, state) => {
+      localStorage.setItem(UI_STATE_STORAGE_KEY, current);
+      localStorage.setItem(
+        LEGACY_SITE_STORAGE_KEY,
+        JSON.stringify({ disabled: true, welcomeScreenDismissed: true })
+      );
+      vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+        throw new Error("Blocked");
+      });
+      expect(readUiState()).toEqual(state);
+      expect(clearUserConfig().ok).toBe(true);
+      expect(localStorage.getItem(UI_STATE_STORAGE_KEY)).toBe(current);
+      expect(readUiState()).toEqual(state);
+    }
+  );
+
+  test("failed v1 migration does not bypass the v2 preview reset requirement", () => {
+    localStorage.setItem(PREVIEW_V2_SITE_STORAGE_KEY, "{}");
+    localStorage.setItem(
+      LEGACY_SITE_STORAGE_KEY,
+      JSON.stringify({ disabled: true })
+    );
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new Error("Blocked");
+    });
+    expect(readUserConfig()).toEqual({ kind: "reset-required" });
   });
 
   test("strict current data is all-or-nothing", () => {

--- a/packages/shared/src/configStorage.ts
+++ b/packages/shared/src/configStorage.ts
@@ -210,12 +210,10 @@ export function migrateLegacySiteConfig(
     : null;
 }
 
-function migrateLegacyStorage(store: Storage) {
+function migrateLegacyStorage(store: Storage): LegacyMigration | null {
   const rawLegacy = store.getItem(LEGACY_SITE_STORAGE_KEY);
-  if (rawLegacy === null) return;
-  const parsedLegacy = parseJson(rawLegacy);
-  if (parsedLegacy === undefined) return;
-  const migration = migrateLegacySiteConfig(parsedLegacy);
+  if (rawLegacy === null) return null;
+  const migration = migrateLegacySiteConfig(parseJson(rawLegacy));
 
   try {
     if (migration && store.getItem(USER_CONFIG_STORAGE_KEY) === null) {
@@ -236,15 +234,16 @@ function migrateLegacyStorage(store: Storage) {
     }
     store.removeItem(LEGACY_SITE_STORAGE_KEY);
   } catch {
-    // Preserve the source when any migration write is blocked or interrupted.
+    // Keep usable legacy values available until all migration writes succeed.
   }
+  return migration;
 }
 
 export function readUserConfig(): ConfigReadResult {
   const store = storage();
   if (!store) return Object.freeze({ kind: "empty" });
   try {
-    migrateLegacyStorage(store);
+    const migration = migrateLegacyStorage(store);
     const raw = store.getItem(USER_CONFIG_STORAGE_KEY);
     if (raw !== null) {
       const parsed = parseJson(raw);
@@ -264,7 +263,9 @@ export function readUserConfig(): ConfigReadResult {
     if (store.getItem(PREVIEW_V2_SITE_STORAGE_KEY) !== null) {
       return Object.freeze({ kind: "reset-required" });
     }
-    return Object.freeze({ kind: "empty" });
+    return migration
+      ? Object.freeze({ kind: "ready", revision: 0, layer: migration.layer })
+      : Object.freeze({ kind: "empty" });
   } catch {
     reportNoStorage();
     return Object.freeze({ kind: "empty" });
@@ -363,6 +364,8 @@ export function clearUserConfig(): ConfigMutationResult {
   const store = storage();
   if (!store) return Object.freeze({ ok: false, reason: "blocked" });
   try {
+    // Remove the migration source first so a partial reset cannot restore it.
+    store.removeItem(LEGACY_SITE_STORAGE_KEY);
     store.removeItem(USER_CONFIG_STORAGE_KEY);
     store.removeItem(PREVIEW_V2_SITE_STORAGE_KEY);
     return Object.freeze({
@@ -378,9 +381,9 @@ export function readUiState(): UiState {
   const store = storage();
   if (!store) return Object.freeze({});
   try {
-    migrateLegacyStorage(store);
+    const migration = migrateLegacyStorage(store);
     const raw = store.getItem(UI_STATE_STORAGE_KEY);
-    if (raw === null) return Object.freeze({});
+    if (raw === null) return migration?.uiState ?? Object.freeze({});
     const parsed = parseJson(raw);
     return parsed === undefined
       ? Object.freeze({})

--- a/packages/ui/src/ActionSettings.test.tsx
+++ b/packages/ui/src/ActionSettings.test.tsx
@@ -62,6 +62,106 @@ async function chooseDraftAction(arrowDowns: number) {
 }
 
 describe("ActionSettings", () => {
+  test.each(["selected", "draft"] as const)(
+    "uses the scope's trusted targets for a %s action",
+    async (mode) => {
+      const write = vi.fn(async (patch: strictConfig.LayerPatchInput) => {
+        void patch;
+        return { ok: true as const };
+      });
+      const globalLayer: LayerView = {
+        editor: { kind: "target", id: "vscode" },
+        bindings: [
+          {
+            trigger: { kind: "modifier-click", modifiers: ["alt"] },
+            action: {
+              kind: "open-editor",
+              destination: { kind: "target", id: "vscode" },
+            },
+          },
+        ],
+      };
+      render(() => (
+        <ActionSettings
+          layers={{
+            default: DEFAULT_LAYER,
+            team: { editor: { kind: "target", id: "page-editor" } },
+            "user-extension": globalLayer,
+          }}
+          targets={{
+            vscode: {
+              label: "Page override",
+              url: "https://page.example/${filePath}",
+            },
+            "page-editor": {
+              label: "Page editor",
+              url: "page://file/${filePath}",
+            },
+          }}
+          scopes={[
+            {
+              layer: "user-extension",
+              label: "All sites",
+              write,
+              editContext: {
+                layers: {
+                  default: DEFAULT_LAYER,
+                  "user-extension": globalLayer,
+                },
+                targets,
+              },
+            },
+          ]}
+        />
+      ));
+
+      await screen
+        .getByRole("button", {
+          name:
+            mode === "selected"
+              ? "Edit action 1: Open in VS Code"
+              : "Add hover toolbar action",
+        })
+        .click();
+      const dialog = within(screen.getByRole("dialog"));
+      await dialog.getByRole("combobox", { name: "Editor" }).click();
+      expect(
+        await screen.findByRole("option", { name: "Editor setting (VS Code)" })
+      ).toBeTruthy();
+      expect(screen.queryByRole("option", { name: "Page editor" })).toBeNull();
+      await fireEvent.click(screen.getByRole("option", { name: /VS Code$/ }));
+      await dialog
+        .getByRole("button", { name: "Customize link template" })
+        .click();
+      await fireEvent.keyDown(
+        dialog.getByRole("textbox", { name: "Custom link template" }),
+        {
+          key: "Enter",
+        }
+      );
+      if (mode === "draft")
+        await dialog.getByRole("button", { name: "Add" }).click();
+
+      await waitFor(() =>
+        expect(write).toHaveBeenLastCalledWith({
+          set: {
+            bindings: expect.arrayContaining([
+              expect.objectContaining({
+                action: {
+                  kind: "open-editor",
+                  destination: {
+                    kind: "template",
+                    template: targets.vscode.url,
+                  },
+                },
+              }),
+            ]),
+          },
+        })
+      );
+    }
+  );
+
   test("opens the selected interaction in a dismissible dialog", async () => {
     render(() => <Harness />);
 

--- a/packages/ui/src/ActionSettings.tsx
+++ b/packages/ui/src/ActionSettings.tsx
@@ -49,11 +49,14 @@ export type ActionSettingsScope = {
   label: string;
   write: (patch: strictConfig.LayerPatchInput) => Promise<WriteResult>;
   /**
-   * Optional trusted layer set used while editing this scope. This lets an
+   * Optional trusted context used while editing this scope. This lets an
    * extension keep page-provided team/site layers visible in SettingsSources
-   * without ever using those untrusted values as the base of a global write.
+   * without using their layers or editor targets as the base of a global write.
    */
-  editLayers?: LayerViews;
+  editContext?: {
+    layers: LayerViews;
+    targets: strictConfig.TargetViewMap;
+  };
   disabled?: boolean;
   disabledReason?: string;
   note?: string;
@@ -198,10 +201,16 @@ export function ActionSettings(props: {
   const activeScope = () =>
     props.scopes.find((scope) => scope.layer === currentLayer()) ??
     props.scopes[0];
-  const editableLayers = () => activeScope()?.editLayers ?? props.layers;
+  const editingContext = () =>
+    activeScope()?.editContext ?? {
+      layers: props.layers,
+      targets: props.targets,
+    };
+  const editableLayers = () => editingContext().layers;
+  const editableTargets = () => editingContext().targets;
   const scopedLayers = () =>
     layersThroughScope(editableLayers(), currentLayer());
-  const snapshot = () => resolveLayerViews(scopedLayers(), props.targets);
+  const snapshot = () => resolveLayerViews(scopedLayers(), editableTargets());
   const effective = () => strictConfig.effectiveOptions(snapshot());
   const bindings = () => strictConfig.encodeBindings(effective().bindings);
   const canInherit = () =>
@@ -364,7 +373,7 @@ export function ActionSettings(props: {
         {(draftBinding) => (
           <ActionInspector
             binding={draftBinding()}
-            targets={props.targets}
+            targets={editableTargets()}
             editor={effectiveEditorDestination(effective().editor)}
             portalMount={props.inspectorMount ?? props.portalMount}
             draft
@@ -384,7 +393,7 @@ export function ActionSettings(props: {
         {(binding) => (
           <ActionInspector
             binding={binding()}
-            targets={props.targets}
+            targets={editableTargets()}
             editor={effectiveEditorDestination(effective().editor)}
             portalMount={props.inspectorMount ?? props.portalMount}
             duplicate={selectedDuplicate()}
@@ -481,16 +490,21 @@ export function ActionSettings(props: {
 
       <Switch>
         <Match when={route() === "studio"}>
-          <EditorSetting
-            layers={scopedLayers()}
-            layer={currentLayer()}
-            targets={props.targets}
-            portalMount={props.portalMount}
-            write={write}
-          />
+          {/* Discard uncommitted editor drafts when their write scope changes. */}
+          <Show when={currentLayer()} keyed>
+            {(layer) => (
+              <EditorSetting
+                layers={scopedLayers()}
+                layer={layer}
+                targets={editableTargets()}
+                portalMount={props.portalMount}
+                write={write}
+              />
+            )}
+          </Show>
           <InteractionStudio
             bindings={bindings()}
-            targets={props.targets}
+            targets={editableTargets()}
             editor={effectiveEditorDestination(effective().editor)}
             selection={selection()}
             onSelect={(next) => {
@@ -515,7 +529,7 @@ export function ActionSettings(props: {
             <AdvancedSettings
               scope={advancedScope()!}
               layers={scopedLayers()}
-              targets={props.targets}
+              targets={editableTargets()}
               portalMount={props.portalMount}
             />
             <SettingsSources


### PR DESCRIPTION
Prevent website editor definitions and unfinished site drafts from becoming All sites settings, and use callback replies for extension origin checks on older Chromium.

Keep usable legacy preferences active when migration cannot persist, discard unusable legacy data, and remove the legacy source during Reset to prevent settings from returning.

Generalize React virtual source URL parsing with regressions for non-Server render stages; this is compatibility hardening, and existing real Next fixtures pass both before and after the parser change.

Validation passed: `pnpm check` (41/41 tasks), `pnpm package-contract`, Chrome/Firefox builds, real extension origin checks on Chromium 143 and 151, and 30 Next Webpack/Turbopack tests across Chromium, Firefox, and WebKit with exact source-path assertions.
